### PR TITLE
added validatePlaybook which can be used to validate a playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,45 @@ It auto-generates the:
 
 **Not for use with Serverless Deployments, instead use the SLS-APB plugin https://github.com/twilio-labs/sls-apb.**
 
-Basic Usage
+#### Validating a Playbook Definition
+
+Use the `validatePlaybook` function as shown below to validate a playbook definition
 
 ```
-const { apb } = require("apb");
+import {validatePlaybook} from "apb/dist/validators"
+// const {validatePlaybook} = require("apb/dist/validators" ) // for non-es6
 
-const renderedStateMachine = new apb(playbookJson)
+const validationResult = validatePlaybook(definition)
+```
+
+validationResult conforms to the ValidationResult interface shown below
+
+```json
+{
+  "isValid": "boolean",
+  "errors": [
+    {
+      "errorCode": "SCHEMA_VALIDATION_ERROR",
+      "message": "string"
+    }
+  ]
+}
+```
+
+### Rendering ASL State machines from playbooks
+
+To render Amazon States Language state machines from playbooks...
+
+```
+import {apb} from "apb";
+// const { apb } = require("apb"); // for non-es6
+
+const {StateMachine} = new apb(playbookJson)
 ```
 
 This repository is the parsing, validation, and rendering engine for translating a SOCless json object into a complete StepFunctions State Machine.
 
-### Writing a playbook
+## Things to note for when Writing a playbook
 
 The default retry object assigned to each `Task` looks like this:
 
@@ -70,19 +98,4 @@ To automatically add a Task Failure Handler to each `Task` state that will trigg
       Task that runs when any step in the playbook fails...
    }
 }
-```
-
-## Feature Flags
-
-To use cloudwatch logs for SOCless playbooks:
-
-1. Ensure that you are on the most recent version of the Socless core stack which is exporting PlaybooksLogGroup as seen [here]()
-2. Add the following to your playbook repo's `serverless.yml`
-
-**serverless.yml:**
-
-```yaml
-custom:
-  sls_apb:
-    logging: true
 ```

--- a/ZPLAN.md
+++ b/ZPLAN.md
@@ -1,4 +1,0 @@
-# This is the rest of the implemetation plan for the APB Changes
-
-- Finalize all the JSON schemas for validation
--

--- a/ZPLAN.md
+++ b/ZPLAN.md
@@ -1,0 +1,4 @@
+# This is the rest of the implemetation plan for the APB Changes
+
+- Finalize all the JSON schemas for validation
+-

--- a/dist/constants.d.ts
+++ b/dist/constants.d.ts
@@ -1,0 +1,20 @@
+export declare const PARSE_SELF_NAME = "apb_render_nonstring_value";
+export declare const DEFAULT_RETRY: Readonly<{
+    ErrorEquals: string[];
+    IntervalSeconds: number;
+    MaxAttempts: number;
+    BackoffRate: number;
+}>;
+export declare const DECORATOR_FLAGS: Readonly<{
+    TaskFailureHandlerName: string;
+    TaskFailureHandlerStartLabel: string;
+    TaskFailureHandlerEndLabel: string;
+}>;
+export declare const PLAYBOOK_FORMATTER_STEP_NAME = "PLAYBOOK_FORMATTER";
+export declare const PLAYBOOK_DIRECT_INVOCATION_CHECK_STEP_NAME = "Was_Playbook_Direct_Executed";
+export declare const PLAYBOOK_SETUP_STEP_NAME = "Setup_Socless_Global_State";
+export declare const SOCLESS_CORE_LAMBDA_NAME_FOR_RUNNING_PLAYBOOK_SETUP = "_socless_setup_global_state_for_direct_invoked_playbook";
+export declare const STATES_EXECUTION_ROLE_ARN = "${{cf:socless-${{self:provider.stage}}.StatesExecutionRoleArn}}";
+export declare const AWS_EVENT_RULE_RESOURCE_TYPE = "AWS::Events::Rule";
+export declare const JSON_SCHEMA_ID_BASE_URI = "http://socless-apb-validator.socless";
+export declare const JSON_SCHEMA_VERSION = "http://json-schema.org/draft-07/schema#";

--- a/dist/constants.js
+++ b/dist/constants.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.AWS_EVENT_RULE_RESOURCE_TYPE = exports.STATES_EXECUTION_ROLE_ARN = exports.SOCLESS_CORE_LAMBDA_NAME_FOR_RUNNING_PLAYBOOK_SETUP = exports.PLAYBOOK_SETUP_STEP_NAME = exports.PLAYBOOK_DIRECT_INVOCATION_CHECK_STEP_NAME = exports.PLAYBOOK_FORMATTER_STEP_NAME = exports.DECORATOR_FLAGS = exports.DEFAULT_RETRY = exports.PARSE_SELF_NAME = void 0;
+exports.JSON_SCHEMA_VERSION = exports.JSON_SCHEMA_ID_BASE_URI = exports.AWS_EVENT_RULE_RESOURCE_TYPE = exports.STATES_EXECUTION_ROLE_ARN = exports.SOCLESS_CORE_LAMBDA_NAME_FOR_RUNNING_PLAYBOOK_SETUP = exports.PLAYBOOK_SETUP_STEP_NAME = exports.PLAYBOOK_DIRECT_INVOCATION_CHECK_STEP_NAME = exports.PLAYBOOK_FORMATTER_STEP_NAME = exports.DECORATOR_FLAGS = exports.DEFAULT_RETRY = exports.PARSE_SELF_NAME = void 0;
 exports.PARSE_SELF_NAME = "apb_render_nonstring_value";
 exports.DEFAULT_RETRY = Object.freeze({
     ErrorEquals: [
@@ -23,3 +23,5 @@ exports.PLAYBOOK_SETUP_STEP_NAME = "Setup_Socless_Global_State";
 exports.SOCLESS_CORE_LAMBDA_NAME_FOR_RUNNING_PLAYBOOK_SETUP = "_socless_setup_global_state_for_direct_invoked_playbook";
 exports.STATES_EXECUTION_ROLE_ARN = "${{cf:socless-${{self:provider.stage}}.StatesExecutionRoleArn}}";
 exports.AWS_EVENT_RULE_RESOURCE_TYPE = "AWS::Events::Rule";
+exports.JSON_SCHEMA_ID_BASE_URI = "http://socless-apb-validator.socless";
+exports.JSON_SCHEMA_VERSION = "http://json-schema.org/draft-07/schema#";

--- a/dist/errors.d.ts
+++ b/dist/errors.d.ts
@@ -1,0 +1,6 @@
+export declare class PlaybookValidationError extends Error {
+    constructor(message: string);
+}
+export declare class PlaybookExtendedConfigValidationError extends Error {
+    constructor(message: string);
+}

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,0 +1,105 @@
+import { StepFunction, State } from "./stepFunction";
+import { PlaybookDefinition, SoclessTaskStepParameters } from "./socless_psuedo_states";
+import { StateMachineYaml } from "./sls_apb";
+export declare class apb {
+    apb_config: any;
+    DecoratorFlags: any;
+    States: Record<string, State>;
+    StateMachine?: StepFunction;
+    Decorators: Record<string, any>;
+    PlaybookName: string;
+    StateMachineYaml: StateMachineYaml;
+    constructor(definition: PlaybookDefinition, apb_config?: {});
+    validateTopLevelKeys(definition: PlaybookDefinition): void;
+    isDefaultRetryDisabled(stateName: string): any;
+    validateTaskFailureHandlerDecorator(config: any): boolean;
+    taskErrorHandlerExists(): any;
+    genIntegrationHelperStateName(originalName: string): string;
+    genTaskFailureHandlerCatchConfig(stateName: string): {
+        ErrorEquals: string[];
+        ResultPath: string;
+        Next: any;
+    };
+    genHelperState(stateConfig: any, stateName: string): {
+        Type: string;
+        Result: {
+            Name: string;
+            Parameters: any;
+        };
+        ResultPath: string;
+        Next: string;
+    };
+    genTaskFailureHandlerStates(TaskFailureHandler: any): {
+        [x: number]: any;
+    };
+    resolveStateName(stateName: string, States?: Record<string, State>): string;
+    transformCatchConfig(catchConfig: any, States: Record<string, State>): any;
+    transformRetryConfig(retryConfig: any, stateName: string): any;
+    defaultTransformState(stateName: any, stateConfig: any, States: any): {
+        [x: number]: any;
+    };
+    transformChoiceState(stateName: any, stateConfig: any, States?: Record<string, State>): {
+        [x: number]: any;
+    };
+    generateParametersForSoclessTask(state_name: string, handle_state_kwargs: Record<string, any>): SoclessTaskStepParameters;
+    generateParametersForSoclessInteraction(state_name: string, handle_state_kwargs: Record<string, any>, function_name: string): {
+        FunctionName: string;
+        Payload: {
+            sfn_context: SoclessTaskStepParameters;
+            "task_token.$": string;
+        };
+    };
+    transformTaskState(stateName: string, stateConfig: any, States: any, DecoratorFlags: any): {};
+    transformInteractionState(stateName: any, stateConfig: any, States: any, DecoratorFlags: any): {};
+    transformParallelState(stateName: any, stateConfig: any, States: any, DecoratorFlags: any): {
+        [x: string]: {};
+        [x: number]: {};
+    };
+    transformStates(States?: Record<string, State>, DecoratorFlags?: any): {};
+    buildLoggingConfiguration(): {};
+    generate_playbook_formatter_step(start_at_step_name: string): {
+        PLAYBOOK_FORMATTER: {
+            Type: string;
+            Parameters: {
+                "execution_id.$": string;
+                "artifacts.$": string;
+                results: {};
+                errors: {};
+            };
+            Next: string;
+        };
+    };
+    generate_playbook_setup_steps(start_at_step_name: string): {
+        PLAYBOOK_FORMATTER: {
+            Type: string;
+            Parameters: {
+                "execution_id.$": string;
+                "artifacts.$": string;
+                results: {};
+                errors: {};
+            };
+            Next: string;
+        };
+        Setup_Socless_Global_State: {
+            Type: string;
+            Resource: string;
+            Parameters: {
+                "execution_id.$": string;
+                "playbook_name.$": string;
+                "playbook_event_details.$": string;
+            };
+            Next: string;
+        };
+        Was_Playbook_Direct_Executed: {
+            Type: string;
+            Choices: {
+                And: {
+                    Variable: string;
+                    IsPresent: boolean;
+                }[];
+                Next: string;
+            }[];
+            Default: string;
+        };
+    };
+}

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -10,29 +10,16 @@ export declare class apb {
     PlaybookName: string;
     StateMachineYaml: StateMachineYaml;
     constructor(definition: PlaybookDefinition, apb_config?: {});
-    validateTopLevelKeys(definition: PlaybookDefinition): void;
     isDefaultRetryDisabled(stateName: string): any;
-    validateTaskFailureHandlerDecorator(config: any): boolean;
     taskErrorHandlerExists(): any;
-    genIntegrationHelperStateName(originalName: string): string;
     genTaskFailureHandlerCatchConfig(stateName: string): {
         ErrorEquals: string[];
         ResultPath: string;
         Next: any;
     };
-    genHelperState(stateConfig: any, stateName: string): {
-        Type: string;
-        Result: {
-            Name: string;
-            Parameters: any;
-        };
-        ResultPath: string;
-        Next: string;
-    };
     genTaskFailureHandlerStates(TaskFailureHandler: any): {
         [x: number]: any;
     };
-    resolveStateName(stateName: string, States?: Record<string, State>): string;
     transformCatchConfig(catchConfig: any, States: Record<string, State>): any;
     transformRetryConfig(retryConfig: any, stateName: string): any;
     defaultTransformState(stateName: any, stateConfig: any, States: any): {
@@ -57,7 +44,7 @@ export declare class apb {
     };
     transformStates(States?: Record<string, State>, DecoratorFlags?: any): {};
     buildLoggingConfiguration(): {};
-    generate_playbook_formatter_step(start_at_step_name: string): {
+    generatePlaybookFormatterStep(startAtStepName: string): {
         PLAYBOOK_FORMATTER: {
             Type: string;
             Parameters: {
@@ -69,7 +56,7 @@ export declare class apb {
             Next: string;
         };
     };
-    generate_playbook_setup_steps(start_at_step_name: string): {
+    generate_playbook_setup_steps(startAtStepName: string): {
         PLAYBOOK_FORMATTER: {
             Type: string;
             Parameters: {

--- a/dist/schemas/choice.json
+++ b/dist/schemas/choice.json
@@ -144,7 +144,8 @@
                     "type": "boolean"
                 }
             },
-            "oneOf": [{
+            "oneOf": [
+                {
                     "required": ["And"]
                 },
                 {

--- a/dist/schemas/choice.json
+++ b/dist/schemas/choice.json
@@ -1,0 +1,309 @@
+{
+    "$id": "http://socless-apb-validator.socless/choice#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "Operator": {
+            "type": "object",
+            "properties": {
+                "Variable": {
+                    "type": "string"
+                },
+                "Next": {
+                    "type": "string"
+                },
+                "And": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Operator"
+                    }
+                },
+                "Or": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Operator"
+                    }
+                },
+                "Not": {
+                    "$ref": "#/definitions/Operator"
+                },
+                "IsNull": {
+                    "type": "boolean"
+                },
+                "IsPresent": {
+                    "type": "boolean"
+                },
+                "BooleanEquals": {
+                    "type": "boolean"
+                },
+                "BooleanEqualsPath": {
+                    "type": "string"
+                },
+                "IsBoolean": {
+                    "type": "boolean"
+                },
+                "NumericEquals": {
+                    "type": "number"
+                },
+                "NumericEqualsPath": {
+                    "type": "string"
+                },
+                "NumericGreaterThan": {
+                    "type": "number"
+                },
+                "NumericGreaterThanPath": {
+                    "type": "string"
+                },
+                "NumericGreaterThanEquals": {
+                    "type": "number"
+                },
+                "NumericGreaterThanEqualsPath": {
+                    "type": "string"
+                },
+                "NumericLessThan": {
+                    "type": "number"
+                },
+                "NumericLessThanPath": {
+                    "type": "string"
+                },
+                "NumericLessThanEquals": {
+                    "type": "number"
+                },
+                "NumericLessThanEqualsPath": {
+                    "type": "string"
+                },
+                "IsNumeric": {
+                    "type": "boolean"
+                },
+                "StringEquals": {
+                    "type": "string"
+                },
+                "StringEqualsPath": {
+                    "type": "string"
+                },
+                "StringGreaterThan": {
+                    "type": "string"
+                },
+                "StringGreaterThanPath": {
+                    "type": "string"
+                },
+                "StringGreaterThanEquals": {
+                    "type": "string"
+                },
+                "StringGreaterThanEqualsPath": {
+                    "type": "string"
+                },
+                "StringLessThan": {
+                    "type": "string"
+                },
+                "StringLessThanPath": {
+                    "type": "string"
+                },
+                "StringLessThanEquals": {
+                    "type": "string"
+                },
+                "StringLessThanEqualsPath": {
+                    "type": "string"
+                },
+                "StringMatches": {
+                    "type": "string"
+                },
+                "IsString": {
+                    "type": "boolean"
+                },
+                "TimestampEquals": {
+                    "type": "string"
+                },
+                "TimestampEqualsPath": {
+                    "type": "string"
+                },
+                "TimestampGreaterThan": {
+                    "type": "string"
+                },
+                "TimestampGreaterThanPath": {
+                    "type": "string"
+                },
+                "TimestampGreaterThanEquals": {
+                    "type": "string"
+                },
+                "TimestampGreaterThanEqualsPath": {
+                    "type": "string"
+                },
+                "TimestampLessThan": {
+                    "type": "string"
+                },
+                "TimestampLessThanPath": {
+                    "type": "string"
+                },
+                "TimestampLessThanEquals": {
+                    "type": "string"
+                },
+                "TimestampLessThanEqualsPath": {
+                    "type": "string"
+                },
+                "IsTimestamp": {
+                    "type": "boolean"
+                }
+            },
+            "oneOf": [{
+                    "required": ["And"]
+                },
+                {
+                    "required": ["BooleanEquals"]
+                },
+                {
+                    "required": ["BooleanEqualsPath"]
+                },
+                {
+                    "required": ["IsBoolean"]
+                },
+                {
+                    "required": ["Not"]
+                },
+                {
+                    "required": ["IsNull"]
+                },
+                {
+                    "required": ["IsPresent"]
+                },
+                {
+                    "required": ["NumericEquals"]
+                },
+                {
+                    "required": ["NumericEqualsPath"]
+                },
+                {
+                    "required": ["NumericGreaterThan"]
+                },
+                {
+                    "required": ["NumericGreaterThanPath"]
+                },
+                {
+                    "required": ["NumericGreaterThanEquals"]
+                },
+                {
+                    "required": ["NumericGreaterThanEqualsPath"]
+                },
+                {
+                    "required": ["NumericLessThan"]
+                },
+                {
+                    "required": ["NumericLessThanPath"]
+                },
+                {
+                    "required": ["NumericLessThanEquals"]
+                },
+                {
+                    "required": ["NumericLessThanEqualsPath"]
+                },
+                {
+                    "required": ["IsNumeric"]
+                },
+                {
+                    "required": ["Or"]
+                },
+                {
+                    "required": ["StringEquals"]
+                },
+                {
+                    "required": ["StringEqualsPath"]
+                },
+                {
+                    "required": ["StringGreaterThan"]
+                },
+                {
+                    "required": ["StringGreaterThanPath"]
+                },
+                {
+                    "required": ["StringGreaterThanEquals"]
+                },
+                {
+                    "required": ["StringGreaterThanEqualsPath"]
+                },
+                {
+                    "required": ["StringLessThan"]
+                },
+                {
+                    "required": ["StringLessThanPath"]
+                },
+                {
+                    "required": ["StringLessThanEquals"]
+                },
+                {
+                    "required": ["StringLessThanEqualsPath"]
+                },
+                {
+                    "required": ["StringMatches"]
+                },
+                {
+                    "required": ["IsString"]
+                },
+                {
+                    "required": ["TimestampEquals"]
+                },
+                {
+                    "required": ["TimestampEqualsPath"]
+                },
+                {
+                    "required": ["TimestampGreaterThan"]
+                },
+                {
+                    "required": ["TimestampGreaterThanPath"]
+                },
+                {
+                    "required": ["TimestampGreaterThanEquals"]
+                },
+                {
+                    "required": ["TimestampGreaterThanEqualsPath"]
+                },
+                {
+                    "required": ["TimestampLessThan"]
+                },
+                {
+                    "required": ["TimestampLessThanPath"]
+                },
+                {
+                    "required": ["TimestampLessThanEquals"]
+                },
+                {
+                    "required": ["TimestampLessThanEqualsPath"]
+                },
+                {
+                    "required": ["IsTimestamp"]
+                }
+            ]
+        }
+    },
+    "type": "object",
+    "properties": {
+        "Type": {
+            "type": "string",
+            "pattern": "^Choice$"
+        },
+        "Next": {
+            "type": "string"
+        },
+        "End": {
+            "enum": [true]
+        },
+        "Comment": {
+            "type": "string"
+        },
+        "OutputPath": {
+            "type": ["string", "null"]
+        },
+        "InputPath": {
+            "type": ["string", "null"]
+        },
+        "Choices": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/Operator"
+            }
+        },
+        "Default": {
+            "type": "string"
+        }
+    },
+    "required": ["Type", "Choices"],
+    "additionalProperties": false
+}

--- a/dist/schemas/decorator-task.json
+++ b/dist/schemas/decorator-task.json
@@ -1,11 +1,11 @@
 {
-    "$id": "http://socless-apb-validator.socless/map#",
+    "$id": "http://socless-apb-validator.socless/decorator-task#",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "properties": {
         "Type": {
             "type": "string",
-            "pattern": "^Map$"
+            "pattern": "^(Task|Interaction)$"
         },
         "Next": {
             "type": "string"
@@ -22,27 +22,18 @@
         "InputPath": {
             "type": ["string", "null"]
         },
-        "ResultPath": {
-            "type": ["string", "null"]
-        },
-        "ItemsPath": {
-            "type": ["string", "null"]
-        },
-        "MaxConcurrency": {
-            "type": "number",
-            "minimum": 0
-        },
-        "Iterator": {
-            "$ref": "http://socless-apb-validator.socless/state-machine#"
-        },
-        "Parameters": {
-            "anyOf": [
-                { "type": "object" },
-                { "type": "array", "items": { "type": "object" } }
+        "Resource": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "object"
+                }
             ]
         },
-        "ResultSelector": {
-            "type": "object"
+        "ResultPath": {
+            "type": ["string", "null"]
         },
         "Retry": {
             "type": "array",
@@ -84,20 +75,43 @@
                     },
                     "Next": {
                         "type": "string"
+                    },
+                    "ResultPath": {
+                        "type": ["string", "null"]
                     }
                 },
                 "required": ["ErrorEquals", "Next"]
             }
+        },
+        "TimeoutSeconds": {
+            "type": "number",
+            "minimum": 1
+        },
+        "TimeoutSecondsPath": {
+            "type": "string"
+        },
+        "HeartbeatSeconds": {
+            "type": "number",
+            "minimum": 1
+        },
+        "HeartbeatSecondsPath": {
+            "type": "string"
+        },
+        "ResultSelector": {
+            "type": "object"
+        },
+        "Parameters": {
+            "anyOf": [
+                { "type": "object" },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "object"
+                    }
+                }
+            ]
         }
     },
-    "oneOf": [
-        {
-            "required": ["Next"]
-        },
-        {
-            "required": ["End"]
-        }
-    ],
-    "required": ["Type", "Iterator"],
+    "required": ["Type", "Resource"],
     "additionalProperties": false
 }

--- a/dist/schemas/decorators-schema.json
+++ b/dist/schemas/decorators-schema.json
@@ -1,5 +1,6 @@
 {
     "$id": "http://socless-apb-validator.socless/decorators#",
+    "type": "object",
     "$schema": "http://json-schema.org/draft-07/schema",
     "properties": {
         "DisableDefaultRetry": {
@@ -14,14 +15,10 @@
             },
             "oneOf": [
                 {
-                    "required": [
-                        "all"
-                    ]
+                    "required": ["all"]
                 },
                 {
-                    "required": [
-                        "tasks"
-                    ]
+                    "required": ["tasks"]
                 }
             ],
             "additionalProperties": false
@@ -29,7 +26,7 @@
         "TaskFailureHandler": {
             "oneOf": [
                 {
-                    "$ref": "http://socless-apb-validator.socless/task#"
+                    "$ref": "http://socless-apb-validator.socless/decorator-task#"
                 },
                 {
                     "$ref": "http://socless-apb-validator.socless/parallel#"

--- a/dist/schemas/decorators-schema.json
+++ b/dist/schemas/decorators-schema.json
@@ -1,0 +1,40 @@
+{
+    "$id": "http://socless-apb-validator.socless/decorators#",
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "properties": {
+        "DisableDefaultRetry": {
+            "type": "object",
+            "properties": {
+                "all": {
+                    "type": "boolean"
+                },
+                "tasks": {
+                    "type": "array"
+                }
+            },
+            "oneOf": [
+                {
+                    "required": [
+                        "all"
+                    ]
+                },
+                {
+                    "required": [
+                        "tasks"
+                    ]
+                }
+            ],
+            "additionalProperties": false
+        },
+        "TaskFailureHandler": {
+            "oneOf": [
+                {
+                    "$ref": "http://socless-apb-validator.socless/task#"
+                },
+                {
+                    "$ref": "http://socless-apb-validator.socless/parallel#"
+                }
+            ]
+        }
+    }
+}

--- a/dist/schemas/fail.json
+++ b/dist/schemas/fail.json
@@ -1,0 +1,28 @@
+{
+    "$id": "http://socless-apb-validator.socless/fail#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "Type": {
+            "type": "string",
+            "pattern": "^Fail$"
+        },
+        "Comment": {
+            "type": "string"
+        },
+        "OutputPath": {
+            "type": ["string", "null"]
+        },
+        "InputPath": {
+            "type": ["string", "null"]
+        },
+        "Cause": {
+            "type": "string"
+        },
+        "Error": {
+            "type": "string"
+        }
+    },
+    "required": ["Type"],
+    "additionalProperties": false
+}

--- a/dist/schemas/map.json
+++ b/dist/schemas/map.json
@@ -1,0 +1,100 @@
+{
+    "$id": "http://socless-apb-validator.socless/map#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "Type": {
+            "type": "string",
+            "pattern": "^Map$"
+        },
+        "Next": {
+            "type": "string"
+        },
+        "End": {
+            "enum": [true]
+        },
+        "Comment": {
+            "type": "string"
+        },
+        "OutputPath": {
+            "type": ["string", "null"]
+        },
+        "InputPath": {
+            "type": ["string", "null"]
+        },
+        "ResultPath": {
+            "type": ["string", "null"]
+        },
+        "ItemsPath": {
+            "type": ["string", "null"]
+        },
+        "MaxConcurrency": {
+            "type": "number",
+            "minimum": 0
+        },
+        "Iterator": {
+            "$ref": "http://socless-apb-validator.socless/state-machine#"
+        },
+        "Parameters": {
+            "type": ["object", "array"],
+            "items": {
+                "type": "object"
+            }
+        },
+        "ResultSelector": {
+            "type": "object"
+        },
+        "Retry": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "ErrorEquals": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "IntervalSeconds": {
+                        "type": "number",
+                        "minimum": 0
+                    },
+                    "MaxAttempts": {
+                        "type": "number",
+                        "minimum": 0
+                    },
+                    "BackoffRate": {
+                        "type": "number",
+                        "minimum": 0
+                    }
+                },
+                "required": ["ErrorEquals"]
+            }
+        },
+        "Catch": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "ErrorEquals": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "Next": {
+                        "type": "string"
+                    }
+                },
+                "required": ["ErrorEquals", "Next"]
+            }
+        }
+    },
+    "oneOf": [{
+            "required": ["Next"]
+        }, {
+            "required": ["End"]
+        }],
+    "required": ["Type", "Iterator"],
+    "additionalProperties": false
+}

--- a/dist/schemas/parallel.json
+++ b/dist/schemas/parallel.json
@@ -7,12 +7,6 @@
             "type": "string",
             "pattern": "^Parallel$"
         },
-        "Parameters": {
-            "type": ["object", "array"],
-            "items": {
-                "type": "object"
-            }
-        },
         "ResultSelector": {
             "type": "object"
         },
@@ -89,11 +83,14 @@
             }
         }
     },
-    "oneOf": [{
+    "oneOf": [
+        {
             "required": ["Next"]
-        }, {
+        },
+        {
             "required": ["End"]
-        }],
+        }
+    ],
     "required": ["Type", "Branches"],
     "additionalProperties": false
 }

--- a/dist/schemas/parallel.json
+++ b/dist/schemas/parallel.json
@@ -1,0 +1,99 @@
+{
+    "$id": "http://socless-apb-validator.socless/parallel#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "Type": {
+            "type": "string",
+            "pattern": "^Parallel$"
+        },
+        "Parameters": {
+            "type": ["object", "array"],
+            "items": {
+                "type": "object"
+            }
+        },
+        "ResultSelector": {
+            "type": "object"
+        },
+        "Next": {
+            "type": "string"
+        },
+        "End": {
+            "enum": [true]
+        },
+        "Comment": {
+            "type": "string"
+        },
+        "OutputPath": {
+            "type": ["string", "null"]
+        },
+        "InputPath": {
+            "type": ["string", "null"]
+        },
+        "ResultPath": {
+            "type": ["string", "null"]
+        },
+        "Branches": {
+            "type": "array",
+            "items": {
+                "$ref": "http://socless-apb-validator.socless/state-machine#"
+            }
+        },
+        "Retry": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "ErrorEquals": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "IntervalSeconds": {
+                        "type": "number",
+                        "minimum": 0
+                    },
+                    "MaxAttempts": {
+                        "type": "number",
+                        "minimum": 0
+                    },
+                    "BackoffRate": {
+                        "type": "number",
+                        "minimum": 0
+                    }
+                },
+                "required": ["ErrorEquals"]
+            }
+        },
+        "Catch": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "ErrorEquals": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "Next": {
+                        "type": "string"
+                    },
+                    "ResultPath": {
+                        "type": ["string", "null"]
+                    }
+                },
+                "required": ["ErrorEquals", "Next"]
+            }
+        }
+    },
+    "oneOf": [{
+            "required": ["Next"]
+        }, {
+            "required": ["End"]
+        }],
+    "required": ["Type", "Branches"],
+    "additionalProperties": false
+}

--- a/dist/schemas/pass.json
+++ b/dist/schemas/pass.json
@@ -26,18 +26,24 @@
             "type": "string"
         },
         "Parameters": {
-            "type": ["object", "array"],
-            "items": {
-                "type": "object"
-            }
+            "anyOf": [
+                { "type": "object" },
+                {
+                    "type": "array",
+                    "items": { "type": "object" }
+                }
+            ]
         },
         "Result": {}
     },
-    "oneOf": [{
+    "oneOf": [
+        {
             "required": ["Next"]
-        }, {
+        },
+        {
             "required": ["End"]
-        }],
+        }
+    ],
     "required": ["Type"],
     "additionalProperties": false
 }

--- a/dist/schemas/pass.json
+++ b/dist/schemas/pass.json
@@ -1,0 +1,43 @@
+{
+    "$id": "http://socless-apb-validator.socless/pass#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "Type": {
+            "type": "string",
+            "pattern": "^Pass$"
+        },
+        "Next": {
+            "type": "string"
+        },
+        "End": {
+            "enum": [true]
+        },
+        "Comment": {
+            "type": "string"
+        },
+        "OutputPath": {
+            "type": ["string", "null"]
+        },
+        "InputPath": {
+            "type": ["string", "null"]
+        },
+        "ResultPath": {
+            "type": "string"
+        },
+        "Parameters": {
+            "type": ["object", "array"],
+            "items": {
+                "type": "object"
+            }
+        },
+        "Result": {}
+    },
+    "oneOf": [{
+            "required": ["Next"]
+        }, {
+            "required": ["End"]
+        }],
+    "required": ["Type"],
+    "additionalProperties": false
+}

--- a/dist/schemas/playbook.json
+++ b/dist/schemas/playbook.json
@@ -1,6 +1,7 @@
 {
     "$id": "http://socless-apb-validator.socless/playbook#",
     "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
     "properties": {
         "Playbook": {
             "description": "Playbook name. Must be alphanumeric",
@@ -15,8 +16,12 @@
         },
         "States": {
             "type": "object",
+            "propertyNames": {
+                "type": "string",
+                "pattern": "^[a-zA-Z0-9_]{1,80}$"
+            },
             "patternProperties": {
-                "^.{1,80}$": {
+                "^[a-zA-Z0-9_]{1,80}$": {
                     "$ref": "http://socless-apb-validator.socless/state#"
                 }
             },

--- a/dist/schemas/playbook.json
+++ b/dist/schemas/playbook.json
@@ -1,0 +1,38 @@
+{
+    "$id": "http://socless-apb-validator.socless/playbook#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+        "Playbook": {
+            "description": "Playbook name. Must be alphanumeric",
+            "type": "string",
+            "pattern": "^[A-Za-z0-9]{1,}$"
+        },
+        "Comment": {
+            "type": "string"
+        },
+        "StartAt": {
+            "type": "string"
+        },
+        "States": {
+            "type": "object",
+            "patternProperties": {
+                "^.{1,80}$": {
+                    "$ref": "http://socless-apb-validator.socless/state#"
+                }
+            },
+            "additionalProperties": false
+        },
+        "Version": {
+            "type": "string"
+        },
+        "TimeoutSeconds": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "Decorators": {
+            "$ref": "http://socless-apb-validator.socless/decorators#"
+        }
+    },
+    "required": ["Playbook", "StartAt", "States"],
+    "additionalProperties": false
+}

--- a/dist/schemas/state-machine.json
+++ b/dist/schemas/state-machine.json
@@ -1,0 +1,30 @@
+{
+    "$id": "http://socless-apb-validator.socless/state-machine#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "Comment": {
+            "type": "string"
+        },
+        "StartAt": {
+            "type": "string"
+        },
+        "States": {
+            "type": "object",
+            "patternProperties": {
+                "^.{1,80}$": {
+                    "$ref": "http://socless-apb-validator.socless/state#"
+                }
+            },
+            "additionalProperties": false
+        },
+        "Version": {
+            "type": "string"
+        },
+        "TimeoutSeconds": {
+            "type": "integer",
+            "minimum": 0
+        }
+    },
+    "required": ["StartAt", "States"]
+}

--- a/dist/schemas/state.json
+++ b/dist/schemas/state.json
@@ -1,0 +1,30 @@
+{
+    "$id": "http://socless-apb-validator.socless/state#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "oneOf": [{
+            "$ref": "http://socless-apb-validator.socless/choice#"
+        },
+        {
+            "$ref": "http://socless-apb-validator.socless/fail#"
+        },
+        {
+            "$ref": "http://socless-apb-validator.socless/parallel#"
+        },
+        {
+            "$ref": "http://socless-apb-validator.socless/pass#"
+        },
+        {
+            "$ref": "http://socless-apb-validator.socless/succeed#"
+        },
+        {
+            "$ref": "http://socless-apb-validator.socless/task#"
+        },
+        {
+            "$ref": "http://socless-apb-validator.socless/wait#"
+        },
+        {
+            "$ref": "http://socless-apb-validator.socless/map#"
+        }
+    ]
+}

--- a/dist/schemas/succeed.json
+++ b/dist/schemas/succeed.json
@@ -1,0 +1,22 @@
+{
+    "$id": "http://socless-apb-validator.socless/succeed#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "Type": {
+            "type": "string",
+            "pattern": "^Succeed$"
+        },
+        "Comment": {
+            "type": "string"
+        },
+        "OutputPath": {
+            "type": ["string", "null"]
+        },
+        "InputPath": {
+            "type": ["string", "null"]
+        }
+    },
+    "required": ["Type"],
+    "additionalProperties": false
+}

--- a/dist/schemas/task.json
+++ b/dist/schemas/task.json
@@ -25,8 +25,7 @@
         "Resource": {
             "oneOf": [
                 {
-                    "type": "string",
-                    "pattern": "^(arn:aws:([a-z]|-)+:([a-z]|[0-9]|-)*:[0-9]*:([a-z]|-)+:[a-zA-Z0-9-_.]+(:(\\$LATEST|[a-zA-Z0-9-_]+))?$)|(\\${.*\\})"
+                    "type": "string"
                 },
                 {
                     "type": "object"
@@ -102,10 +101,15 @@
             "type": "object"
         },
         "Parameters": {
-            "type": ["object", "array"],
-            "items": {
-                "type": "object"
-            }
+            "anyOf": [
+                { "type": "object" },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "object"
+                    }
+                }
+            ]
         }
     },
     "oneOf": [

--- a/dist/schemas/task.json
+++ b/dist/schemas/task.json
@@ -1,0 +1,121 @@
+{
+    "$id": "http://socless-apb-validator.socless/task#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "Type": {
+            "type": "string",
+            "pattern": "^(Task|Interaction)$"
+        },
+        "Next": {
+            "type": "string"
+        },
+        "End": {
+            "enum": [true]
+        },
+        "Comment": {
+            "type": "string"
+        },
+        "OutputPath": {
+            "type": ["string", "null"]
+        },
+        "InputPath": {
+            "type": ["string", "null"]
+        },
+        "Resource": {
+            "oneOf": [
+                {
+                    "type": "string",
+                    "pattern": "^(arn:aws:([a-z]|-)+:([a-z]|[0-9]|-)*:[0-9]*:([a-z]|-)+:[a-zA-Z0-9-_.]+(:(\\$LATEST|[a-zA-Z0-9-_]+))?$)|(\\${.*\\})"
+                },
+                {
+                    "type": "object"
+                }
+            ]
+        },
+        "ResultPath": {
+            "type": ["string", "null"]
+        },
+        "Retry": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "ErrorEquals": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "IntervalSeconds": {
+                        "type": "number",
+                        "minimum": 0
+                    },
+                    "MaxAttempts": {
+                        "type": "number",
+                        "minimum": 0
+                    },
+                    "BackoffRate": {
+                        "type": "number",
+                        "minimum": 0
+                    }
+                },
+                "required": ["ErrorEquals"]
+            }
+        },
+        "Catch": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "ErrorEquals": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "Next": {
+                        "type": "string"
+                    },
+                    "ResultPath": {
+                        "type": ["string", "null"]
+                    }
+                },
+                "required": ["ErrorEquals", "Next"]
+            }
+        },
+        "TimeoutSeconds": {
+            "type": "number",
+            "minimum": 1
+        },
+        "TimeoutSecondsPath": {
+            "type": "string"
+        },
+        "HeartbeatSeconds": {
+            "type": "number",
+            "minimum": 1
+        },
+        "HeartbeatSecondsPath": {
+            "type": "string"
+        },
+        "ResultSelector": {
+            "type": "object"
+        },
+        "Parameters": {
+            "type": ["object", "array"],
+            "items": {
+                "type": "object"
+            }
+        }
+    },
+    "oneOf": [
+        {
+            "required": ["Next"]
+        },
+        {
+            "required": ["End"]
+        }
+    ],
+    "required": ["Type", "Resource"],
+    "additionalProperties": false
+}

--- a/dist/schemas/wait.json
+++ b/dist/schemas/wait.json
@@ -1,0 +1,51 @@
+{
+    "$id": "http://socless-apb-validator.socless/wait#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "Type": {
+            "type": "string",
+            "pattern": "^Wait$"
+        },
+        "Next": {
+            "type": "string"
+        },
+        "End": {
+            "enum": [true]
+        },
+        "Comment": {
+            "type": "string"
+        },
+        "OutputPath": {
+            "type": ["string", "null"]
+        },
+        "InputPath": {
+            "type": ["string", "null"]
+        },
+        "Seconds": {
+            "oneOf": [
+                { "type": "number", "minimum": 0 },
+                { "type": "string", "pattern": "^apb_render_nonstring_value\\(.+\\)$" }
+            ]
+        },
+        "Timestamp": {
+            "type": "string"
+        },
+        "SecondsPath": {
+            "type": ["string", "null"]
+        },
+        "TimestampPath": {
+            "type": ["string", "null"]
+        }
+    },
+    "oneOf": [
+        {
+            "required": ["Next"]
+        },
+        {
+            "required": ["End"]
+        }
+    ],
+    "required": ["Type"],
+    "additionalProperties": false
+}

--- a/dist/sls_apb.d.ts
+++ b/dist/sls_apb.d.ts
@@ -1,0 +1,12 @@
+export interface ApbConfig {
+    logging?: boolean;
+    playbooksFolder?: string;
+}
+export interface StateMachineYaml {
+    Resources: object;
+    Outputs: object;
+}
+export interface SlsApbVariableResolutionHelper {
+    statesExecutionRole: string;
+    renderedPlaybooks: object;
+}

--- a/dist/socless_psuedo_states.d.ts
+++ b/dist/socless_psuedo_states.d.ts
@@ -1,0 +1,37 @@
+import { BaseState, State } from "./stepFunction";
+export interface HelperState extends BaseState {
+    Resource: string;
+}
+export interface HelperStateFinalized extends BaseState {
+    Type: "Pass";
+    Result: {
+        Name: string;
+        Parameters: Record<string, any>;
+    };
+    ResultPath: "$.State_Config";
+    Next: string;
+}
+export interface PlaybookDefinition {
+    Playbook: string;
+    States: Record<string, State>;
+    Decorators: Record<string, any>;
+    StartAt: string;
+    Comment?: string;
+}
+export interface SoclessTaskStepParameters {
+    "execution_id.$": "$.execution_id";
+    "artifacts.$": "$.artifacts";
+    "errors.$": "$.errors";
+    "results.$": "$.results";
+    "State_Config": {
+        "Name": string;
+        "Parameters": Record<string, any>;
+    };
+}
+export interface SoclessInteractionStepParameters {
+    FunctionName: string;
+    Payload: {
+        "sfn_context.$": SoclessTaskStepParameters;
+        "task_token.$": "$$.Task.Token";
+    };
+}

--- a/dist/stepFunction.d.ts
+++ b/dist/stepFunction.d.ts
@@ -1,0 +1,76 @@
+export interface StepFunction {
+    StartAt: string;
+    States: Record<string, State | any>;
+    Playbook?: string;
+    Comment?: string;
+}
+export interface BaseState {
+    Type: string;
+    Next?: string;
+    Catch?: any[];
+    Retry?: any[];
+    End?: boolean;
+}
+export interface TaskState extends BaseState {
+    Type: "Task";
+    Resource: string;
+    Parameters?: Record<string, any>;
+}
+interface FailState extends BaseState {
+    Type: "Fail";
+    Cause?: string;
+    Error?: string;
+}
+interface SucceedState extends BaseState {
+    Type: "Succeed";
+}
+interface PassState extends BaseState {
+    Type: "Pass";
+}
+interface WaitState extends BaseState {
+    Type: "Wait";
+    Seconds: Number;
+}
+interface MapState extends BaseState {
+    Type: "Map";
+    Iterator: StepFunction;
+}
+interface ChoiceState extends BaseState {
+    Type: "Choice";
+    Choices?: Operator[];
+    Default: string;
+}
+export interface Operator {
+    Variable?: string;
+    Next?: string;
+    And?: Operator[];
+    Or?: Operator[];
+    Not?: Operator;
+    BooleanEquals?: boolean;
+    NumericEquals?: number;
+    NumericGreaterThan?: number;
+    NumericGreaterThanEquals?: number;
+    NumericLessThan?: number;
+    NumericLessThanEquals?: number;
+    StringEquals?: string;
+    StringGreaterThan?: string;
+    StringGreaterThanEquals?: string;
+    StringLessThan?: string;
+    StringLessThanEquals?: string;
+    TimestampEquals?: string;
+    TimestampGreaterThan?: string;
+    TimestampGreaterThanEquals?: string;
+    TimestampLessThan?: string;
+    TimestampLessThanEquals?: string;
+}
+interface ParallelState extends BaseState {
+    Type: "Parallel";
+    Branches: StepFunction[];
+}
+export interface InteractionState extends BaseState {
+    Type: "Interaction";
+    Resource: string;
+    Parameters: Record<string, any>;
+}
+export declare type State = TaskState | FailState | SucceedState | MapState | ChoiceState | ParallelState | PassState | InteractionState | WaitState;
+export {};

--- a/dist/validators.d.ts
+++ b/dist/validators.d.ts
@@ -1,0 +1,15 @@
+export interface ValidationErrorObject {
+    errorCode: string;
+    message: string;
+}
+export interface ValidationResult {
+    isValid: boolean;
+    errors: ValidationErrorObject[];
+}
+/**
+ * Validates that a SOCless Playbook definition has the correct JSON schema
+ * AND follows all ASL rules.
+ * NOTE: This function is not fully implemented but is ready for use in an alpha state
+ * @param definition SOCless playbook definition
+ */
+export declare function validatePlaybook(definition: any): ValidationResult;

--- a/dist/validators.d.ts
+++ b/dist/validators.d.ts
@@ -13,3 +13,12 @@ export interface ValidationResult {
  * @param definition SOCless playbook definition
  */
 export declare function validatePlaybook(definition: any): ValidationResult;
+/**
+ * Validate that a Playbook's name abides by the expected schema in
+ * schemas/playbook.json:$.properties.Playbook
+ */
+export declare const validatePlaybookName: (data: any) => ValidationResult;
+/**
+ * Validates that a State name abides by the schema
+ */
+export declare const validateStateName: (data: any) => ValidationResult;

--- a/dist/validators.js
+++ b/dist/validators.js
@@ -1,0 +1,90 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.validatePlaybook = void 0;
+var ajv_1 = __importDefault(require("ajv"));
+var choice_json_1 = __importDefault(require("./schemas/choice.json"));
+var fail_json_1 = __importDefault(require("./schemas/fail.json"));
+var map_json_1 = __importDefault(require("./schemas/map.json"));
+var parallel_json_1 = __importDefault(require("./schemas/parallel.json"));
+var pass_json_1 = __importDefault(require("./schemas/pass.json"));
+var state_machine_json_1 = __importDefault(require("./schemas/state-machine.json"));
+var state_json_1 = __importDefault(require("./schemas/state.json"));
+var succeed_json_1 = __importDefault(require("./schemas/succeed.json"));
+var task_json_1 = __importDefault(require("./schemas/task.json"));
+var wait_json_1 = __importDefault(require("./schemas/wait.json"));
+var decorators_schema_json_1 = __importDefault(require("./schemas/decorators-schema.json"));
+var playbook_json_1 = __importDefault(require("./schemas/playbook.json"));
+/**
+ * Transforms ajv error objects into our ValidationErrorObject
+ * @param errors list of ajv ErrorObjects
+ */
+function restructureAjvErrors(errors) {
+    return errors.map(function (errObj) { return ({
+        errorCode: "SCHEMA_VALIDATION_ERROR",
+        message: errObj.dataPath + " " + errObj.message + ". " + Object.entries(errObj.params)
+            .map(function (each) { return each.join(":"); })
+            .join(", "),
+    }); });
+}
+/**
+ * Validates that the JSON structures within a playbook JSON obey the appropriate schema
+ * DOES NOT completely validate that the playbook is valid according to all the rules laid
+ * laid out in the Amazon States Language spec. Examples of rules not checked by this function
+ * include:
+ * - Ensuring a playbook has a terminal state
+ * - Ensuring all states within the playbook are reachable
+ */
+function validatePlaybookJsonSchema(definition) {
+    if (definition === undefined) {
+        throw new Error("Playbook definition is undefined");
+    }
+    // build an instance of ajv using schemas that for a valid  playbook.json
+    var ajv = new ajv_1.default({
+        schemas: [
+            playbook_json_1.default,
+            state_machine_json_1.default,
+            decorators_schema_json_1.default,
+            choice_json_1.default,
+            fail_json_1.default,
+            map_json_1.default,
+            parallel_json_1.default,
+            pass_json_1.default,
+            state_json_1.default,
+            succeed_json_1.default,
+            task_json_1.default,
+            wait_json_1.default,
+        ],
+        allErrors: true,
+    });
+    var validate = ajv.getSchema(playbook_json_1.default.$id);
+    if (typeof validate === "undefined") {
+        throw new Error("Failed to create validator for playbookJsonSchema.");
+    }
+    var isValid = validate(definition);
+    if (typeof isValid !== "boolean") {
+        throw new Error("Ajv validator returned non-boolean response. This needs internal investigation into why");
+    }
+    var validationErrs = validate.errors;
+    var errors = [];
+    if (validationErrs) {
+        errors = restructureAjvErrors(validationErrs);
+    }
+    return {
+        isValid: isValid,
+        errors: errors,
+    };
+}
+/**
+ * Validates that a SOCless Playbook definition has the correct JSON schema
+ * AND follows all ASL rules.
+ * NOTE: This function is not fully implemented but is ready for use in an alpha state
+ * @param definition SOCless playbook definition
+ */
+function validatePlaybook(definition) {
+    //TODO: Extend this to return the results from validateASLRules as well
+    return validatePlaybookJsonSchema(definition);
+}
+exports.validatePlaybook = validatePlaybook;

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -25,3 +25,6 @@ export const STATES_EXECUTION_ROLE_ARN =
   "${{cf:socless-${{self:provider.stage}}.StatesExecutionRoleArn}}";
 
 export const AWS_EVENT_RULE_RESOURCE_TYPE = "AWS::Events::Rule";
+
+export const JSON_SCHEMA_ID_BASE_URI = "http://socless-apb-validator.socless";
+export const JSON_SCHEMA_VERSION = "http://json-schema.org/draft-07/schema#";

--- a/lib/schemas/README.md
+++ b/lib/schemas/README.md
@@ -2,4 +2,11 @@
 
 This folder contains JSON Schemas used for validation of input data
 
-Some of the schemas in the section rely on schemas contained in the [asl-validator](https://github.com/ChristopheBougere/asl-validator/tree/master/src/schemas) library
+The schemas in this section are lifted from [asl-validator library](https://github.com/ChristopheBougere/asl-validator/tree/master/src/schemas) and modified to support the SOCless Playbook Schema.
+
+**Note from developer:** Lifting all the schemas was probably overkill as some of them can be used as-is by importing them from asl-validator. They were lifted and put here to support the effort to get validation working first, as lifting all of them was faster than figuring out which ones could be lifted as-is vs which ones needed slight modification. In the future, this can likely be refactored to import them from asl-validator instead, reducing the amount of code managed here.
+
+Changes that were made to the provided schemas include:
+
+- task.json schema pattern for Type property was modified from `^Task$` to `^(Task|Interaction)$` to account for SOCless Playbooks Interaction state which have the same schema as task
+- wait.json: Seconds was update from number to a pattern that allows either a number or the pattern `apb_render_nonstring_value()` which SOCless playbooks allow

--- a/lib/schemas/README.md
+++ b/lib/schemas/README.md
@@ -1,0 +1,5 @@
+# Schemas
+
+This folder contains JSON Schemas used for validation of input data
+
+Some of the schemas in the section rely on schemas contained in the [asl-validator](https://github.com/ChristopheBougere/asl-validator/tree/master/src/schemas) library

--- a/lib/schemas/choice.json
+++ b/lib/schemas/choice.json
@@ -144,7 +144,8 @@
           "type": "boolean"
         }
       },
-      "oneOf": [{
+      "oneOf": [
+        {
           "required": ["And"]
         },
         {

--- a/lib/schemas/choice.json
+++ b/lib/schemas/choice.json
@@ -1,0 +1,309 @@
+{
+  "$id": "http://socless-apb-validator.socless/choice#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Operator": {
+      "type": "object",
+      "properties": {
+        "Variable": {
+          "type": "string"
+        },
+        "Next": {
+          "type": "string"
+        },
+        "And": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Operator"
+          }
+        },
+        "Or": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Operator"
+          }
+        },
+        "Not": {
+          "$ref": "#/definitions/Operator"
+        },
+        "IsNull": {
+          "type": "boolean"
+        },
+        "IsPresent": {
+          "type": "boolean"
+        },
+        "BooleanEquals": {
+          "type": "boolean"
+        },
+        "BooleanEqualsPath": {
+          "type": "string"
+        },
+        "IsBoolean": {
+          "type": "boolean"
+        },
+        "NumericEquals": {
+          "type": "number"
+        },
+        "NumericEqualsPath": {
+          "type": "string"
+        },
+        "NumericGreaterThan": {
+          "type": "number"
+        },
+        "NumericGreaterThanPath": {
+          "type": "string"
+        },
+        "NumericGreaterThanEquals": {
+          "type": "number"
+        },
+        "NumericGreaterThanEqualsPath": {
+          "type": "string"
+        },
+        "NumericLessThan": {
+          "type": "number"
+        },
+        "NumericLessThanPath": {
+          "type": "string"
+        },
+        "NumericLessThanEquals": {
+          "type": "number"
+        },
+        "NumericLessThanEqualsPath": {
+          "type": "string"
+        },
+        "IsNumeric": {
+          "type": "boolean"
+        },
+        "StringEquals": {
+          "type": "string"
+        },
+        "StringEqualsPath": {
+          "type": "string"
+        },
+        "StringGreaterThan": {
+          "type": "string"
+        },
+        "StringGreaterThanPath": {
+          "type": "string"
+        },
+        "StringGreaterThanEquals": {
+          "type": "string"
+        },
+        "StringGreaterThanEqualsPath": {
+          "type": "string"
+        },
+        "StringLessThan": {
+          "type": "string"
+        },
+        "StringLessThanPath": {
+          "type": "string"
+        },
+        "StringLessThanEquals": {
+          "type": "string"
+        },
+        "StringLessThanEqualsPath": {
+          "type": "string"
+        },
+        "StringMatches": {
+          "type": "string"
+        },
+        "IsString": {
+          "type": "boolean"
+        },
+        "TimestampEquals": {
+          "type": "string"
+        },
+        "TimestampEqualsPath": {
+          "type": "string"
+        },
+        "TimestampGreaterThan": {
+          "type": "string"
+        },
+        "TimestampGreaterThanPath": {
+          "type": "string"
+        },
+        "TimestampGreaterThanEquals": {
+          "type": "string"
+        },
+        "TimestampGreaterThanEqualsPath": {
+          "type": "string"
+        },
+        "TimestampLessThan": {
+          "type": "string"
+        },
+        "TimestampLessThanPath": {
+          "type": "string"
+        },
+        "TimestampLessThanEquals": {
+          "type": "string"
+        },
+        "TimestampLessThanEqualsPath": {
+          "type": "string"
+        },
+        "IsTimestamp": {
+          "type": "boolean"
+        }
+      },
+      "oneOf": [{
+          "required": ["And"]
+        },
+        {
+          "required": ["BooleanEquals"]
+        },
+        {
+          "required": ["BooleanEqualsPath"]
+        },
+        {
+          "required": ["IsBoolean"]
+        },
+        {
+          "required": ["Not"]
+        },
+        {
+          "required": ["IsNull"]
+        },
+        {
+          "required": ["IsPresent"]
+        },
+        {
+          "required": ["NumericEquals"]
+        },
+        {
+          "required": ["NumericEqualsPath"]
+        },
+        {
+          "required": ["NumericGreaterThan"]
+        },
+        {
+          "required": ["NumericGreaterThanPath"]
+        },
+        {
+          "required": ["NumericGreaterThanEquals"]
+        },
+        {
+          "required": ["NumericGreaterThanEqualsPath"]
+        },
+        {
+          "required": ["NumericLessThan"]
+        },
+        {
+          "required": ["NumericLessThanPath"]
+        },
+        {
+          "required": ["NumericLessThanEquals"]
+        },
+        {
+          "required": ["NumericLessThanEqualsPath"]
+        },
+        {
+          "required": ["IsNumeric"]
+        },
+        {
+          "required": ["Or"]
+        },
+        {
+          "required": ["StringEquals"]
+        },
+        {
+          "required": ["StringEqualsPath"]
+        },
+        {
+          "required": ["StringGreaterThan"]
+        },
+        {
+          "required": ["StringGreaterThanPath"]
+        },
+        {
+          "required": ["StringGreaterThanEquals"]
+        },
+        {
+          "required": ["StringGreaterThanEqualsPath"]
+        },
+        {
+          "required": ["StringLessThan"]
+        },
+        {
+          "required": ["StringLessThanPath"]
+        },
+        {
+          "required": ["StringLessThanEquals"]
+        },
+        {
+          "required": ["StringLessThanEqualsPath"]
+        },
+        {
+          "required": ["StringMatches"]
+        },
+        {
+          "required": ["IsString"]
+        },
+        {
+          "required": ["TimestampEquals"]
+        },
+        {
+          "required": ["TimestampEqualsPath"]
+        },
+        {
+          "required": ["TimestampGreaterThan"]
+        },
+        {
+          "required": ["TimestampGreaterThanPath"]
+        },
+        {
+          "required": ["TimestampGreaterThanEquals"]
+        },
+        {
+          "required": ["TimestampGreaterThanEqualsPath"]
+        },
+        {
+          "required": ["TimestampLessThan"]
+        },
+        {
+          "required": ["TimestampLessThanPath"]
+        },
+        {
+          "required": ["TimestampLessThanEquals"]
+        },
+        {
+          "required": ["TimestampLessThanEqualsPath"]
+        },
+        {
+          "required": ["IsTimestamp"]
+        }
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "Type": {
+      "type": "string",
+      "pattern": "^Choice$"
+    },
+    "Next": {
+      "type": "string"
+    },
+    "End": {
+      "enum": [true]
+    },
+    "Comment": {
+      "type": "string"
+    },
+    "OutputPath": {
+      "type": ["string", "null"]
+    },
+    "InputPath": {
+      "type": ["string", "null"]
+    },
+    "Choices": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Operator"
+      }
+    },
+    "Default": {
+      "type": "string"
+    }
+  },
+  "required": ["Type", "Choices"],
+  "additionalProperties": false
+}

--- a/lib/schemas/decorator-task.json
+++ b/lib/schemas/decorator-task.json
@@ -1,11 +1,11 @@
 {
-  "$id": "http://socless-apb-validator.socless/map#",
+  "$id": "http://socless-apb-validator.socless/decorator-task#",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
     "Type": {
       "type": "string",
-      "pattern": "^Map$"
+      "pattern": "^(Task|Interaction)$"
     },
     "Next": {
       "type": "string"
@@ -22,27 +22,18 @@
     "InputPath": {
       "type": ["string", "null"]
     },
-    "ResultPath": {
-      "type": ["string", "null"]
-    },
-    "ItemsPath": {
-      "type": ["string", "null"]
-    },
-    "MaxConcurrency": {
-      "type": "number",
-      "minimum": 0
-    },
-    "Iterator": {
-      "$ref": "http://socless-apb-validator.socless/state-machine#"
-    },
-    "Parameters": {
-      "anyOf": [
-        { "type": "object" },
-        { "type": "array", "items": { "type": "object" } }
+    "Resource": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object"
+        }
       ]
     },
-    "ResultSelector": {
-      "type": "object"
+    "ResultPath": {
+      "type": ["string", "null"]
     },
     "Retry": {
       "type": "array",
@@ -84,20 +75,43 @@
           },
           "Next": {
             "type": "string"
+          },
+          "ResultPath": {
+            "type": ["string", "null"]
           }
         },
         "required": ["ErrorEquals", "Next"]
       }
+    },
+    "TimeoutSeconds": {
+      "type": "number",
+      "minimum": 1
+    },
+    "TimeoutSecondsPath": {
+      "type": "string"
+    },
+    "HeartbeatSeconds": {
+      "type": "number",
+      "minimum": 1
+    },
+    "HeartbeatSecondsPath": {
+      "type": "string"
+    },
+    "ResultSelector": {
+      "type": "object"
+    },
+    "Parameters": {
+      "anyOf": [
+        { "type": "object" },
+        {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      ]
     }
   },
-  "oneOf": [
-    {
-      "required": ["Next"]
-    },
-    {
-      "required": ["End"]
-    }
-  ],
-  "required": ["Type", "Iterator"],
+  "required": ["Type", "Resource"],
   "additionalProperties": false
 }

--- a/lib/schemas/decorators-schema.json
+++ b/lib/schemas/decorators-schema.json
@@ -1,0 +1,40 @@
+{
+  "$id": "http://socless-apb-validator.socless/decorators#",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "properties": {
+    "DisableDefaultRetry": {
+      "type": "object",
+      "properties": {
+        "all": {
+          "type": "boolean"
+        },
+        "tasks": {
+          "type": "array"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "all"
+          ]
+        },
+        {
+          "required": [
+            "tasks"
+          ]
+        }
+      ],
+      "additionalProperties": false
+    },
+    "TaskFailureHandler": {
+      "oneOf": [
+        {
+          "$ref": "http://socless-apb-validator.socless/task#"
+        },
+        {
+          "$ref": "http://socless-apb-validator.socless/parallel#"
+        }
+      ]
+    }
+  }
+}

--- a/lib/schemas/decorators-schema.json
+++ b/lib/schemas/decorators-schema.json
@@ -1,5 +1,6 @@
 {
   "$id": "http://socless-apb-validator.socless/decorators#",
+  "type": "object",
   "$schema": "http://json-schema.org/draft-07/schema",
   "properties": {
     "DisableDefaultRetry": {
@@ -14,14 +15,10 @@
       },
       "oneOf": [
         {
-          "required": [
-            "all"
-          ]
+          "required": ["all"]
         },
         {
-          "required": [
-            "tasks"
-          ]
+          "required": ["tasks"]
         }
       ],
       "additionalProperties": false
@@ -29,7 +26,7 @@
     "TaskFailureHandler": {
       "oneOf": [
         {
-          "$ref": "http://socless-apb-validator.socless/task#"
+          "$ref": "http://socless-apb-validator.socless/decorator-task#"
         },
         {
           "$ref": "http://socless-apb-validator.socless/parallel#"

--- a/lib/schemas/fail.json
+++ b/lib/schemas/fail.json
@@ -1,0 +1,28 @@
+{
+  "$id": "http://socless-apb-validator.socless/fail#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "Type": {
+      "type": "string",
+      "pattern": "^Fail$"
+    },
+    "Comment": {
+      "type": "string"
+    },
+    "OutputPath": {
+      "type": ["string", "null"]
+    },
+    "InputPath": {
+      "type": ["string", "null"]
+    },
+    "Cause": {
+      "type": "string"
+    },
+    "Error": {
+      "type": "string"
+    }
+  },
+  "required": ["Type"],
+  "additionalProperties": false
+}

--- a/lib/schemas/map.json
+++ b/lib/schemas/map.json
@@ -1,0 +1,100 @@
+{
+  "$id": "http://socless-apb-validator.socless/map#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "Type": {
+      "type": "string",
+      "pattern": "^Map$"
+    },
+    "Next": {
+      "type": "string"
+    },
+    "End": {
+      "enum": [true]
+    },
+    "Comment": {
+      "type": "string"
+    },
+    "OutputPath": {
+      "type": ["string", "null"]
+    },
+    "InputPath": {
+      "type": ["string", "null"]
+    },
+    "ResultPath": {
+      "type": ["string", "null"]
+    },
+    "ItemsPath": {
+      "type": ["string", "null"]
+    },
+    "MaxConcurrency": {
+      "type": "number",
+      "minimum": 0
+    },
+    "Iterator": {
+      "$ref": "http://socless-apb-validator.socless/state-machine#"
+    },
+    "Parameters": {
+      "type": ["object", "array"],
+      "items": {
+        "type": "object"
+      }
+    },
+    "ResultSelector": {
+      "type": "object"
+    },
+    "Retry": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "ErrorEquals": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "IntervalSeconds": {
+            "type": "number",
+            "minimum": 0
+          },
+          "MaxAttempts": {
+            "type": "number",
+            "minimum": 0
+          },
+          "BackoffRate": {
+            "type": "number",
+            "minimum": 0
+          }
+        },
+        "required": ["ErrorEquals"]
+      }
+    },
+    "Catch": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "ErrorEquals": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "Next": {
+            "type": "string"
+          }
+        },
+        "required": ["ErrorEquals", "Next"]
+      }
+    }
+  },
+  "oneOf": [{
+    "required": ["Next"]
+  }, {
+    "required": ["End"]
+  }],
+  "required": ["Type", "Iterator"],
+  "additionalProperties": false
+}

--- a/lib/schemas/parallel.json
+++ b/lib/schemas/parallel.json
@@ -7,12 +7,6 @@
       "type": "string",
       "pattern": "^Parallel$"
     },
-    "Parameters": {
-      "type": ["object", "array"],
-      "items": {
-        "type": "object"
-      }
-    },
     "ResultSelector": {
       "type": "object"
     },
@@ -89,11 +83,14 @@
       }
     }
   },
-  "oneOf": [{
-    "required": ["Next"]
-  }, {
-    "required": ["End"]
-  }],
+  "oneOf": [
+    {
+      "required": ["Next"]
+    },
+    {
+      "required": ["End"]
+    }
+  ],
   "required": ["Type", "Branches"],
   "additionalProperties": false
 }

--- a/lib/schemas/parallel.json
+++ b/lib/schemas/parallel.json
@@ -1,0 +1,99 @@
+{
+  "$id": "http://socless-apb-validator.socless/parallel#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "Type": {
+      "type": "string",
+      "pattern": "^Parallel$"
+    },
+    "Parameters": {
+      "type": ["object", "array"],
+      "items": {
+        "type": "object"
+      }
+    },
+    "ResultSelector": {
+      "type": "object"
+    },
+    "Next": {
+      "type": "string"
+    },
+    "End": {
+      "enum": [true]
+    },
+    "Comment": {
+      "type": "string"
+    },
+    "OutputPath": {
+      "type": ["string", "null"]
+    },
+    "InputPath": {
+      "type": ["string", "null"]
+    },
+    "ResultPath": {
+      "type": ["string", "null"]
+    },
+    "Branches": {
+      "type": "array",
+      "items": {
+        "$ref": "http://socless-apb-validator.socless/state-machine#"
+      }
+    },
+    "Retry": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "ErrorEquals": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "IntervalSeconds": {
+            "type": "number",
+            "minimum": 0
+          },
+          "MaxAttempts": {
+            "type": "number",
+            "minimum": 0
+          },
+          "BackoffRate": {
+            "type": "number",
+            "minimum": 0
+          }
+        },
+        "required": ["ErrorEquals"]
+      }
+    },
+    "Catch": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "ErrorEquals": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "Next": {
+            "type": "string"
+          },
+          "ResultPath": {
+            "type": ["string", "null"]
+          }
+        },
+        "required": ["ErrorEquals", "Next"]
+      }
+    }
+  },
+  "oneOf": [{
+    "required": ["Next"]
+  }, {
+    "required": ["End"]
+  }],
+  "required": ["Type", "Branches"],
+  "additionalProperties": false
+}

--- a/lib/schemas/pass.json
+++ b/lib/schemas/pass.json
@@ -1,0 +1,43 @@
+{
+  "$id": "http://socless-apb-validator.socless/pass#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "Type": {
+      "type": "string",
+      "pattern": "^Pass$"
+    },
+    "Next": {
+      "type": "string"
+    },
+    "End": {
+      "enum": [true]
+    },
+    "Comment": {
+      "type": "string"
+    },
+    "OutputPath": {
+      "type": ["string", "null"]
+    },
+    "InputPath": {
+      "type": ["string", "null"]
+    },
+    "ResultPath": {
+      "type": "string"
+    },
+    "Parameters": {
+      "type": ["object", "array"],
+      "items": {
+        "type": "object"
+      }
+    },
+    "Result": {}
+  },
+  "oneOf": [{
+    "required": ["Next"]
+  }, {
+    "required": ["End"]
+  }],
+  "required": ["Type"],
+  "additionalProperties": false
+}

--- a/lib/schemas/pass.json
+++ b/lib/schemas/pass.json
@@ -26,18 +26,24 @@
       "type": "string"
     },
     "Parameters": {
-      "type": ["object", "array"],
-      "items": {
-        "type": "object"
-      }
+      "anyOf": [
+        { "type": "object" },
+        {
+          "type": "array",
+          "items": { "type": "object" }
+        }
+      ]
     },
     "Result": {}
   },
-  "oneOf": [{
-    "required": ["Next"]
-  }, {
-    "required": ["End"]
-  }],
+  "oneOf": [
+    {
+      "required": ["Next"]
+    },
+    {
+      "required": ["End"]
+    }
+  ],
   "required": ["Type"],
   "additionalProperties": false
 }

--- a/lib/schemas/playbook.json
+++ b/lib/schemas/playbook.json
@@ -1,0 +1,39 @@
+{
+	"$id": "http://socless-apb-validator.socless/playbook#",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"properties": {
+
+		"Playbook": {
+			"description": "Playbook name. Must be alphanumeric",
+			"type": "string",
+			"pattern": "^[A-Za-z0-9]{1,}$"
+		},
+		"Comment": {
+			"type": "string"
+		},
+		"StartAt": {
+			"type": "string"
+		},
+		"States": {
+			"type": "object",
+			"patternProperties": {
+				"^.{1,80}$": {
+					"$ref": "http://socless-apb-validator.socless/state#"
+				}
+			},
+			"additionalProperties": false
+		},
+		"Version": {
+			"type": "string"
+		},
+		"TimeoutSeconds": {
+			"type": "integer",
+			"minimum": 0
+		},
+		"Decorators": {
+			"$ref": "http://socless-apb-validator.socless/decorators#"
+		}
+	},
+	"required": ["Playbook", "StartAt", "States"],
+    "additionalProperties": false
+}

--- a/lib/schemas/playbook.json
+++ b/lib/schemas/playbook.json
@@ -1,39 +1,43 @@
 {
-	"$id": "http://socless-apb-validator.socless/playbook#",
-	"$schema": "http://json-schema.org/draft-07/schema#",
-	"properties": {
-
-		"Playbook": {
-			"description": "Playbook name. Must be alphanumeric",
-			"type": "string",
-			"pattern": "^[A-Za-z0-9]{1,}$"
-		},
-		"Comment": {
-			"type": "string"
-		},
-		"StartAt": {
-			"type": "string"
-		},
-		"States": {
-			"type": "object",
-			"patternProperties": {
-				"^.{1,80}$": {
-					"$ref": "http://socless-apb-validator.socless/state#"
-				}
-			},
-			"additionalProperties": false
-		},
-		"Version": {
-			"type": "string"
-		},
-		"TimeoutSeconds": {
-			"type": "integer",
-			"minimum": 0
-		},
-		"Decorators": {
-			"$ref": "http://socless-apb-validator.socless/decorators#"
-		}
-	},
-	"required": ["Playbook", "StartAt", "States"],
-    "additionalProperties": false
+  "$id": "http://socless-apb-validator.socless/playbook#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "Playbook": {
+      "description": "Playbook name. Must be alphanumeric",
+      "type": "string",
+      "pattern": "^[A-Za-z0-9]{1,}$"
+    },
+    "Comment": {
+      "type": "string"
+    },
+    "StartAt": {
+      "type": "string"
+    },
+    "States": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string",
+        "pattern": "^[a-zA-Z0-9_]{1,80}$"
+      },
+      "patternProperties": {
+        "^[a-zA-Z0-9_]{1,80}$": {
+          "$ref": "http://socless-apb-validator.socless/state#"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Version": {
+      "type": "string"
+    },
+    "TimeoutSeconds": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "Decorators": {
+      "$ref": "http://socless-apb-validator.socless/decorators#"
+    }
+  },
+  "required": ["Playbook", "StartAt", "States"],
+  "additionalProperties": false
 }

--- a/lib/schemas/state-machine.json
+++ b/lib/schemas/state-machine.json
@@ -1,0 +1,30 @@
+{
+  "$id": "http://socless-apb-validator.socless/state-machine#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "Comment": {
+      "type": "string"
+    },
+    "StartAt": {
+      "type": "string"
+    },
+    "States": {
+      "type": "object",
+      "patternProperties": {
+        "^.{1,80}$": {
+          "$ref": "http://socless-apb-validator.socless/state#"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Version": {
+      "type": "string"
+    },
+    "TimeoutSeconds": {
+      "type": "integer",
+      "minimum": 0
+    }
+  },
+  "required": ["StartAt", "States"]
+}

--- a/lib/schemas/state.json
+++ b/lib/schemas/state.json
@@ -1,0 +1,30 @@
+{
+  "$id": "http://socless-apb-validator.socless/state#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "oneOf": [{
+      "$ref": "http://socless-apb-validator.socless/choice#"
+    },
+    {
+      "$ref": "http://socless-apb-validator.socless/fail#"
+    },
+    {
+      "$ref": "http://socless-apb-validator.socless/parallel#"
+    },
+    {
+      "$ref": "http://socless-apb-validator.socless/pass#"
+    },
+    {
+      "$ref": "http://socless-apb-validator.socless/succeed#"
+    },
+    {
+      "$ref": "http://socless-apb-validator.socless/task#"
+    },
+    {
+      "$ref": "http://socless-apb-validator.socless/wait#"
+    },
+    {
+      "$ref": "http://socless-apb-validator.socless/map#"
+    }
+  ]
+}

--- a/lib/schemas/succeed.json
+++ b/lib/schemas/succeed.json
@@ -1,0 +1,22 @@
+{
+  "$id": "http://socless-apb-validator.socless/succeed#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "Type": {
+      "type": "string",
+      "pattern": "^Succeed$"
+    },
+    "Comment": {
+      "type": "string"
+    },
+    "OutputPath": {
+      "type": ["string", "null"]
+    },
+    "InputPath": {
+      "type": ["string", "null"]
+    }
+  },
+  "required": ["Type"],
+  "additionalProperties": false
+}

--- a/lib/schemas/task.json
+++ b/lib/schemas/task.json
@@ -25,8 +25,7 @@
     "Resource": {
       "oneOf": [
         {
-          "type": "string",
-          "pattern": "^(arn:aws:([a-z]|-)+:([a-z]|[0-9]|-)*:[0-9]*:([a-z]|-)+:[a-zA-Z0-9-_.]+(:(\\$LATEST|[a-zA-Z0-9-_]+))?$)|(\\${.*\\})"
+          "type": "string"
         },
         {
           "type": "object"
@@ -102,10 +101,15 @@
       "type": "object"
     },
     "Parameters": {
-      "type": ["object", "array"],
-      "items": {
-        "type": "object"
-      }
+      "anyOf": [
+        { "type": "object" },
+        {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      ]
     }
   },
   "oneOf": [

--- a/lib/schemas/task.json
+++ b/lib/schemas/task.json
@@ -1,0 +1,121 @@
+{
+  "$id": "http://socless-apb-validator.socless/task#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "Type": {
+      "type": "string",
+      "pattern": "^(Task|Interaction)$"
+    },
+    "Next": {
+      "type": "string"
+    },
+    "End": {
+      "enum": [true]
+    },
+    "Comment": {
+      "type": "string"
+    },
+    "OutputPath": {
+      "type": ["string", "null"]
+    },
+    "InputPath": {
+      "type": ["string", "null"]
+    },
+    "Resource": {
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^(arn:aws:([a-z]|-)+:([a-z]|[0-9]|-)*:[0-9]*:([a-z]|-)+:[a-zA-Z0-9-_.]+(:(\\$LATEST|[a-zA-Z0-9-_]+))?$)|(\\${.*\\})"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "ResultPath": {
+      "type": ["string", "null"]
+    },
+    "Retry": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "ErrorEquals": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "IntervalSeconds": {
+            "type": "number",
+            "minimum": 0
+          },
+          "MaxAttempts": {
+            "type": "number",
+            "minimum": 0
+          },
+          "BackoffRate": {
+            "type": "number",
+            "minimum": 0
+          }
+        },
+        "required": ["ErrorEquals"]
+      }
+    },
+    "Catch": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "ErrorEquals": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "Next": {
+            "type": "string"
+          },
+          "ResultPath": {
+            "type": ["string", "null"]
+          }
+        },
+        "required": ["ErrorEquals", "Next"]
+      }
+    },
+    "TimeoutSeconds": {
+      "type": "number",
+      "minimum": 1
+    },
+    "TimeoutSecondsPath": {
+      "type": "string"
+    },
+    "HeartbeatSeconds": {
+      "type": "number",
+      "minimum": 1
+    },
+    "HeartbeatSecondsPath": {
+      "type": "string"
+    },
+    "ResultSelector": {
+      "type": "object"
+    },
+    "Parameters": {
+      "type": ["object", "array"],
+      "items": {
+        "type": "object"
+      }
+    }
+  },
+  "oneOf": [
+    {
+      "required": ["Next"]
+    },
+    {
+      "required": ["End"]
+    }
+  ],
+  "required": ["Type", "Resource"],
+  "additionalProperties": false
+}

--- a/lib/schemas/wait.json
+++ b/lib/schemas/wait.json
@@ -1,0 +1,51 @@
+{
+  "$id": "http://socless-apb-validator.socless/wait#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "Type": {
+      "type": "string",
+      "pattern": "^Wait$"
+    },
+    "Next": {
+      "type": "string"
+    },
+    "End": {
+      "enum": [true]
+    },
+    "Comment": {
+      "type": "string"
+    },
+    "OutputPath": {
+      "type": ["string", "null"]
+    },
+    "InputPath": {
+      "type": ["string", "null"]
+    },
+    "Seconds": {
+      "oneOf": [
+        { "type": "number", "minimum": 0 },
+        { "type": "string", "pattern": "^apb_render_nonstring_value\\(.+\\)$" }
+      ]
+    },
+    "Timestamp": {
+      "type": "string"
+    },
+    "SecondsPath": {
+      "type": ["string", "null"]
+    },
+    "TimestampPath": {
+      "type": ["string", "null"]
+    }
+  },
+  "oneOf": [
+    {
+      "required": ["Next"]
+    },
+    {
+      "required": ["End"]
+    }
+  ],
+  "required": ["Type"],
+  "additionalProperties": false
+}

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -13,12 +13,12 @@ import waitSchema from "./schemas/wait.json";
 import decoratorSchema from "./schemas/decorators-schema.json";
 import playbookSchema from "./schemas/playbook.json";
 
-interface ValidationErrorObject {
+export interface ValidationErrorObject {
   errorCode: string;
   message: string;
 }
 
-interface ValidationResult {
+export interface ValidationResult {
   isValid: boolean;
   errors: ValidationErrorObject[];
 }

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -1,0 +1,103 @@
+import Ajv, { ErrorObject } from "ajv";
+import aslValidator from "asl-validator";
+import choiceSchema from "./schemas/choice.json";
+import failSchema from "./schemas/fail.json";
+import mapSchema from "./schemas/map.json";
+import parallelSchema from "./schemas/parallel.json";
+import passSchema from "./schemas/pass.json";
+import stateMachineSchema from "./schemas/state-machine.json";
+import stateSchema from "./schemas/state.json";
+import succeedSchema from "./schemas/succeed.json";
+import taskSchema from "./schemas/task.json";
+import waitSchema from "./schemas/wait.json";
+import decoratorSchema from "./schemas/decorators-schema.json";
+import playbookSchema from "./schemas/playbook.json";
+
+interface ValidationErrorObject {
+  errorCode: string;
+  message: string;
+}
+
+interface ValidationResult {
+  isValid: boolean;
+  errors: ValidationErrorObject[];
+}
+
+/**
+ * Transforms ajv error objects into our ValidationErrorObject
+ * @param errors list of ajv ErrorObjects
+ */
+function restructureAjvErrors(errors: ErrorObject[]): ValidationErrorObject[] {
+  return errors.map((errObj: ErrorObject) => ({
+    errorCode: "SCHEMA_VALIDATION_ERROR",
+    message: `${errObj.dataPath} ${errObj.message}. ${Object.entries(
+      errObj.params
+    )
+      .map((each) => each.join(":"))
+      .join(", ")}`,
+  }));
+}
+
+/**
+ * Validates that the JSON structures within a playbook JSON obey the appropriate schema
+ * DOES NOT completely validate that the playbook is valid according to all the rules laid
+ * laid out in the Amazon States Language spec. Examples of rules not checked by this function
+ * include:
+ * - Ensuring a playbook has a terminal state
+ * - Ensuring all states within the playbook are reachable
+ */
+function validatePlaybookJsonSchema(definition): ValidationResult {
+  if (definition === undefined) {
+    throw new Error("Playbook definition is undefined");
+  }
+  // build an instance of ajv using schemas that for a valid  playbook.json
+  const ajv = new Ajv({
+    schemas: [
+      playbookSchema,
+      stateMachineSchema,
+      decoratorSchema,
+      choiceSchema,
+      failSchema,
+      mapSchema,
+      parallelSchema,
+      passSchema,
+      stateSchema,
+      succeedSchema,
+      taskSchema,
+      waitSchema,
+    ],
+    allErrors: true,
+  });
+
+  const validate = ajv.getSchema(playbookSchema.$id);
+  if (typeof validate === "undefined") {
+    throw new Error("Failed to create validator for playbookJsonSchema.");
+  }
+  const isValid = validate(definition);
+  if (typeof isValid !== "boolean") {
+    throw new Error(
+      "Ajv validator returned non-boolean response. This needs internal investigation into why"
+    );
+  }
+  const validationErrs = validate.errors;
+
+  let errors: ValidationErrorObject[] = [];
+  if (validationErrs) {
+    errors = restructureAjvErrors(validationErrs);
+  }
+  return {
+    isValid,
+    errors,
+  };
+}
+
+/**
+ * Validates that a SOCless Playbook definition has the correct JSON schema
+ * AND follows all ASL rules.
+ * NOTE: This function is not fully implemented but is ready for use in an alpha state
+ * @param definition SOCless playbook definition
+ */
+export function validatePlaybook(definition): ValidationResult {
+  //TODO: Extend this to return the results from validateASLRules as well
+  return validatePlaybookJsonSchema(definition);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,14 +11,68 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.2.tgz",
+      "integrity": "sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
+      }
+    },
+    "ajv-cli": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-cli/-/ajv-cli-5.0.0.tgz",
+      "integrity": "sha512-LY4m6dUv44HTyhV+u2z5uX4EhPYTM38Iv1jdgDJJJCyOOuqB8KtZEGjPZ2T+sh5ZIJrXUfgErYx/j3gLd3+PlQ==",
+      "requires": {
+        "ajv": "^8.0.0",
+        "fast-json-patch": "^2.0.0",
+        "glob": "^7.1.0",
+        "js-yaml": "^3.14.0",
+        "json-schema-migrate": "^2.0.0",
+        "json5": "^2.1.3",
+        "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.6.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.2.tgz",
+          "integrity": "sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
       }
     },
     "ansi-colors": {
@@ -58,21 +112,10 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
-    "asl-validator": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/asl-validator/-/asl-validator-1.10.0.tgz",
-      "integrity": "sha512-N7/ouOzYaEJqUNf82NarTs6Cg8sZMnHIDVGULjhzw7GLyXgoXkQUZrhvHXCyucvkU4FfeHmzY3TynEjl0/UN3Q==",
-      "requires": {
-        "ajv": "^6.12.6",
-        "commander": "^5.1.0",
-        "jsonpath": "^1.1.0"
-      }
-    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -84,7 +127,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -208,16 +250,10 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "commander": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "debug": {
       "version": "4.3.1",
@@ -241,11 +277,6 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
       "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
       "dev": true
-    },
-    "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "diff": {
       "version": "5.0.0",
@@ -271,54 +302,25 @@
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true
     },
-    "escodegen": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-      "requires": {
-        "esprima": "^4.0.1",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-        }
-      }
-    },
-    "esprima": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
-      "integrity": "sha1-dqD9Zvz+FU/SkmZ9wmQBl1CxZXs="
-    },
-    "estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
-    },
-    "esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
-    "fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
-    },
-    "fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    "fast-json-patch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
+      "integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
+      "requires": {
+        "fast-deep-equal": "^2.0.1"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        }
+      }
     },
     "fill-range": {
       "version": "7.0.1",
@@ -348,8 +350,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "2.3.2",
@@ -368,7 +369,6 @@
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
       "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -409,7 +409,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -418,8 +417,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -484,28 +482,43 @@
         "argparse": "^2.0.1"
       }
     },
-    "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-    },
-    "jsonpath": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.1.1.tgz",
-      "integrity": "sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==",
+    "json-schema-migrate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-migrate/-/json-schema-migrate-2.0.0.tgz",
+      "integrity": "sha512-r38SVTtojDRp4eD6WsCqiE0eNDt4v1WalBXb9cyZYw9ai5cGtBwzRNWjHzJl38w6TxFkXAIA7h+fyX3tnrAFhQ==",
       "requires": {
-        "esprima": "1.2.2",
-        "static-eval": "2.0.2",
-        "underscore": "1.12.1"
+        "ajv": "^8.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.6.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.2.tgz",
+          "integrity": "sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
       }
     },
-    "levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+    "json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "json5": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "minimist": "^1.2.5"
       }
     },
     "locate-path": {
@@ -531,10 +544,14 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mocha": {
       "version": "9.0.2",
@@ -591,22 +608,8 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
-      }
-    },
-    "optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
       }
     },
     "p-limit": {
@@ -636,19 +639,13 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
       "dev": true
-    },
-    "prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "prettier": {
       "version": "2.3.2",
@@ -685,6 +682,11 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -700,19 +702,10 @@
         "randombytes": "^2.1.0"
       }
     },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "optional": true
-    },
-    "static-eval": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
-      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
-      "requires": {
-        "escodegen": "^1.8.1"
-      }
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "string-width": {
       "version": "2.1.1",
@@ -757,24 +750,11 @@
         "is-number": "^7.0.0"
       }
     },
-    "type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "requires": {
-        "prelude-ls": "~1.1.2"
-      }
-    },
     "typescript": {
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
       "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true
-    },
-    "underscore": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
     "uri-js": {
       "version": "4.4.1",
@@ -801,11 +781,6 @@
       "requires": {
         "string-width": "^1.0.2 || 2"
       }
-    },
-    "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
     "workerpool": {
       "version": "6.1.5",
@@ -861,8 +836,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "y18n": {
       "version": "5.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,60 +21,6 @@
         "uri-js": "^4.2.2"
       }
     },
-    "ajv-cli": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-cli/-/ajv-cli-5.0.0.tgz",
-      "integrity": "sha512-LY4m6dUv44HTyhV+u2z5uX4EhPYTM38Iv1jdgDJJJCyOOuqB8KtZEGjPZ2T+sh5ZIJrXUfgErYx/j3gLd3+PlQ==",
-      "requires": {
-        "ajv": "^8.0.0",
-        "fast-json-patch": "^2.0.0",
-        "glob": "^7.1.0",
-        "js-yaml": "^3.14.0",
-        "json-schema-migrate": "^2.0.0",
-        "json5": "^2.1.3",
-        "minimist": "^1.2.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "8.6.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.2.tgz",
-          "integrity": "sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "argparse": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
-        },
-        "esprima": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-        },
-        "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-        }
-      }
-    },
     "ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -115,7 +61,8 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -127,6 +74,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -253,7 +201,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "debug": {
       "version": "4.3.1",
@@ -307,21 +256,6 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
-    "fast-json-patch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
-      "integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
-      "requires": {
-        "fast-deep-equal": "^2.0.1"
-      },
-      "dependencies": {
-        "fast-deep-equal": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-        }
-      }
-    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -350,7 +284,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "2.3.2",
@@ -369,6 +304,7 @@
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
       "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -409,6 +345,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -417,7 +354,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -482,44 +420,10 @@
         "argparse": "^2.0.1"
       }
     },
-    "json-schema-migrate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-migrate/-/json-schema-migrate-2.0.0.tgz",
-      "integrity": "sha512-r38SVTtojDRp4eD6WsCqiE0eNDt4v1WalBXb9cyZYw9ai5cGtBwzRNWjHzJl38w6TxFkXAIA7h+fyX3tnrAFhQ==",
-      "requires": {
-        "ajv": "^8.0.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "8.6.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.2.tgz",
-          "integrity": "sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-        }
-      }
-    },
     "json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "requires": {
-        "minimist": "^1.2.5"
-      }
     },
     "locate-path": {
       "version": "6.0.0",
@@ -544,14 +448,10 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
-    },
-    "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mocha": {
       "version": "9.0.2",
@@ -608,6 +508,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -639,7 +540,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "picomatch": {
       "version": "2.3.0",
@@ -701,11 +603,6 @@
       "requires": {
         "randombytes": "^2.1.0"
       }
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "string-width": {
       "version": "2.1.1",
@@ -836,7 +733,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "y18n": {
       "version": "5.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "apb",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9,6 +9,17 @@
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
     },
     "ansi-colors": {
       "version": "4.1.1",
@@ -46,6 +57,16 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "asl-validator": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/asl-validator/-/asl-validator-1.10.0.tgz",
+      "integrity": "sha512-N7/ouOzYaEJqUNf82NarTs6Cg8sZMnHIDVGULjhzw7GLyXgoXkQUZrhvHXCyucvkU4FfeHmzY3TynEjl0/UN3Q==",
+      "requires": {
+        "ajv": "^6.12.6",
+        "commander": "^5.1.0",
+        "jsonpath": "^1.1.0"
+      }
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -187,6 +208,11 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -216,6 +242,11 @@
       "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
       "dev": true
     },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+    },
     "diff": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -239,6 +270,55 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true
+    },
+    "escodegen": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+        }
+      }
+    },
+    "esprima": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
+      "integrity": "sha1-dqD9Zvz+FU/SkmZ9wmQBl1CxZXs="
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fill-range": {
       "version": "7.0.1",
@@ -404,6 +484,30 @@
         "argparse": "^2.0.1"
       }
     },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "jsonpath": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.1.1.tgz",
+      "integrity": "sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==",
+      "requires": {
+        "esprima": "1.2.2",
+        "static-eval": "2.0.2",
+        "underscore": "1.12.1"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
     "locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -492,6 +596,19 @@
         "wrappy": "1"
       }
     },
+    "optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      }
+    },
     "p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -528,11 +645,21 @@
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
       "dev": true
     },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+    },
     "prettier": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
       "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
       "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -571,6 +698,20 @@
       "dev": true,
       "requires": {
         "randombytes": "^2.1.0"
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "optional": true
+    },
+    "static-eval": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
+      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
+      "requires": {
+        "escodegen": "^1.8.1"
       }
     },
     "string-width": {
@@ -616,11 +757,32 @@
         "is-number": "^7.0.0"
       }
     },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
     "typescript": {
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
       "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true
+    },
+    "underscore": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
     },
     "which": {
       "version": "2.0.2",
@@ -639,6 +801,11 @@
       "requires": {
         "string-width": "^1.0.2 || 2"
       }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
     "workerpool": {
       "version": "6.1.5",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "author": "Ubani Balogun",
   "license": "Apache-2.0",
   "dependencies": {
-    "asl-validator": "1.10.0"
+    "ajv": "^8.6.2",
+    "ajv-cli": "^5.0.0"
   },
   "devDependencies": {
     "mocha": "^9.0.2",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "SOCless Automation Playbook Builder",
   "main": "dist/index.js",
   "scripts": {
-    "build": "rm -rf ./dist && tsc",
-    "test": "rm -rf ./dist && tsc && ./node_modules/.bin/mocha"
+    "build": "rm -rf ./dist && tsc --declaration",
+    "test": "rm -rf ./dist && tsc --declaration && ./node_modules/.bin/mocha"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "SOCless Automation Playbook Builder",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc",
-    "test": "tsc && ./node_modules/.bin/mocha"
+    "build": "rm -rf ./dist && tsc",
+    "test": "rm -rf ./dist && tsc && ./node_modules/.bin/mocha"
   },
   "repository": {
     "type": "git",
@@ -18,7 +18,9 @@
   ],
   "author": "Ubani Balogun",
   "license": "Apache-2.0",
-  "dependencies": {},
+  "dependencies": {
+    "asl-validator": "1.10.0"
+  },
   "devDependencies": {
     "mocha": "^9.0.2",
     "prettier": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   "author": "Ubani Balogun",
   "license": "Apache-2.0",
   "dependencies": {
-    "ajv": "^8.6.2",
-    "ajv-cli": "^5.0.0"
+    "ajv": "^8.6.2"
   },
   "devDependencies": {
     "mocha": "^9.0.2",

--- a/test/mocks/index.js
+++ b/test/mocks/index.js
@@ -3,6 +3,7 @@ const general_playbooks = require("./playbooks/general");
 const task_failure_handlers = require("./playbooks/task_failure_handlers");
 const full_playbooks = require("./playbooks/full_playbooks");
 const error_playbooks = require("./playbooks/error_playbooks");
+const hello_world = require("./playbooks/hello_world/playbook.json");
 
 // re-export for easy usage in tests
 module.exports = {
@@ -10,4 +11,5 @@ module.exports = {
   ...task_failure_handlers,
   ...full_playbooks,
   ...error_playbooks,
+  ...{ hello_world },
 };

--- a/test/mocks/playbooks/expected_output_pb_parallel_and_interaction/playbook.json
+++ b/test/mocks/playbooks/expected_output_pb_parallel_and_interaction/playbook.json
@@ -1,1 +1,337 @@
-{"Comment":"Sample Playbook to Geolocate an IP","StartAt":"Was_Playbook_Direct_Executed","States":{"Was_Playbook_Direct_Executed":{"Type":"Choice","Choices":[{"And":[{"Variable":"$.artifacts","IsPresent":true},{"Variable":"$.execution_id","IsPresent":true},{"Variable":"$.errors","IsPresent":false},{"Variable":"$.results","IsPresent":false}],"Next":"PLAYBOOK_FORMATTER"},{"And":[{"Variable":"$.artifacts","IsPresent":true},{"Variable":"$.execution_id","IsPresent":true},{"Variable":"$.errors","IsPresent":true},{"Variable":"$.results","IsPresent":true}],"Next":"New_Interaction_State"}],"Default":"Setup_Socless_Global_State"},"Setup_Socless_Global_State":{"Type":"Task","Resource":"arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:_socless_setup_global_state_for_direct_invoked_playbook","Parameters":{"execution_id.$":"$$.Execution.Name","playbook_name.$":"$$.StateMachine.Name","playbook_event_details.$":"$$.Execution.Input"},"Next":"New_Interaction_State"},"PLAYBOOK_FORMATTER":{"Type":"Pass","Parameters":{"execution_id.$":"$.execution_id","artifacts.$":"$.artifacts","results":{},"errors":{}},"Next":"New_Interaction_State"},"New_Interaction_State":{"Type":"Task","Resource":"arn:aws:states:::lambda:invoke.waitForTaskToken","Parameters":{"FunctionName":"${{self:custom.slack.PromptForConfirmation}}","Payload":{"sfn_context":{"execution_id.$":"$.execution_id","artifacts.$":"$.artifacts","errors.$":"$.errors","results.$":"$.results","State_Config":{"Name":"New_Interaction_State","Parameters":{"no_text":"No","prompt_text":"Are you happy?","receiver":"Slack_User_For_Response","target":"$.results.Validate_Username.name","target_type":"user","text":"Hi, are you happy?","yes_text":"Yes"}}},"task_token.$":"$$.Task.Token"}},"Next":"Slack_User_For_Response","Retry":[{"ErrorEquals":["Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}]},"Slack_User_For_Response":{"Type":"Task","Parameters":{"execution_id.$":"$.execution_id","artifacts.$":"$.artifacts","errors.$":"$.errors","results.$":"$.results","State_Config":{"Name":"Slack_User_For_Response","Parameters":{"no_text":"No","prompt_text":"Are you happy?","receiver":"Await_User_Response","target":"$.results.Validate_Username.name","target_type":"user","text":"Hi, are you happy?","yes_text":"Yes"}}},"Catch":[{"ErrorEquals":["States.ALL"],"Next":"Is_User_Happy"}],"Retry":[{"ErrorEquals":["ConnectionError"],"IntervalSeconds":30,"MaxAttempts":2,"BackoffRate":2},{"ErrorEquals":["Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Resource":"${{self:custom.slack.PromptForConfirmation}}","Next":"Await_User_Response"},"Await_User_Response":{"Type":"Task","Resource":"${{self:custom.core.AwaitMessageResponseActivity}}","Retry":[{"ErrorEquals":["Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["Lambda.ServiceException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Next":"Is_User_Happy"},"Is_User_Happy":{"Type":"Choice","Choices":[{"Variable":"$.results.result","StringEquals":"false","Next":"User_Is_Not_Happy"}],"Default":"User_Is_Happy"},"User_Is_Happy":{"Type":"Pass","Next":"Celebrate_With_User"},"Celebrate_With_User":{"Type":"Task","Parameters":{"execution_id.$":"$.execution_id","artifacts.$":"$.artifacts","errors.$":"$.errors","results.$":"$.results","State_Config":{"Name":"Celebrate_With_User","Parameters":{"message_template":"I'm happy too! Yay!","target":"user","target_type":"channel"}}},"Resource":"${{self:custom.slack.SendMessage}}","Next":"Mark_As_Success","Retry":[{"ErrorEquals":["Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}]},"Mark_As_Success":{"Type":"Succeed"},"User_Is_Not_Happy":{"Type":"Pass","Next":"Parallel_Cheer_User_Up"},"Parallel_Cheer_User_Up":{"Type":"Parallel","Next":"merge_parallel_cheer_user_up","Branches":[{"StartAt":"Slack_User_Happiness","States":{"Slack_User_Happiness":{"Type":"Task","Parameters":{"execution_id.$":"$.execution_id","artifacts.$":"$.artifacts","errors.$":"$.errors","results.$":"$.results","State_Config":{"Name":"Slack_User_Happiness","Parameters":{"message_template":"I'm happy too! Yay!","target":"user","target_type":"channel"}}},"Resource":"${{self:custom.slack.PromptForConfirmation}}","End":true,"Retry":[{"ErrorEquals":["Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}]}}},{"StartAt":"Order_Pizza_For_User","States":{"Order_Pizza_For_User":{"Type":"Task","Parameters":{"execution_id.$":"$.execution_id","artifacts.$":"$.artifacts","errors.$":"$.errors","results.$":"$.results","State_Config":{"Name":"Order_Pizza_For_User","Parameters":{"type":"bbq with bacon bits","restaurant":"Five10 Pizza"}}},"Resource":"${{self:custom.hubgrub.PlaceOrder}}","Next":"Pour_Coffee_For_User","Retry":[{"ErrorEquals":["Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}]},"Pour_Coffee_For_User":{"Type":"Task","Parameters":{"execution_id.$":"$.execution_id","artifacts.$":"$.artifacts","errors.$":"$.errors","results.$":"$.results","State_Config":{"Name":"Pour_Coffee_For_User","Parameters":{"how":"coffee, sugar, cream"}}},"Resource":"${{self:custom.iotBrewer.PourCoffee}}","End":true,"Retry":[{"ErrorEquals":["Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}]}}}]},"merge_parallel_cheer_user_up":{"Type":"Task","Resource":"${{self:custom.core.MergeParallelOutput}}","Catch":[],"Retry":[{"ErrorEquals":["Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Next":"End_Cheer_Up"},"End_Cheer_Up":{"Type":"Task","Parameters":{"execution_id.$":"$.execution_id","artifacts.$":"$.artifacts","errors.$":"$.errors","results.$":"$.results","State_Config":{"Name":"End_Cheer_Up","Parameters":{"status":"done"}}},"Resource":"${{self.custom.jira.TransitionIssue}}","End":true}}}
+{
+  "Comment": "Sample Playbook to Geolocate an IP",
+  "StartAt": "Was_Playbook_Direct_Executed",
+  "States": {
+    "Was_Playbook_Direct_Executed": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "And": [
+            { "Variable": "$.artifacts", "IsPresent": true },
+            { "Variable": "$.execution_id", "IsPresent": true },
+            { "Variable": "$.errors", "IsPresent": false },
+            { "Variable": "$.results", "IsPresent": false }
+          ],
+          "Next": "PLAYBOOK_FORMATTER"
+        },
+        {
+          "And": [
+            { "Variable": "$.artifacts", "IsPresent": true },
+            { "Variable": "$.execution_id", "IsPresent": true },
+            { "Variable": "$.errors", "IsPresent": true },
+            { "Variable": "$.results", "IsPresent": true }
+          ],
+          "Next": "New_Interaction_State"
+        }
+      ],
+      "Default": "Setup_Socless_Global_State"
+    },
+    "Setup_Socless_Global_State": {
+      "Type": "Task",
+      "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:_socless_setup_global_state_for_direct_invoked_playbook",
+      "Parameters": {
+        "execution_id.$": "$$.Execution.Name",
+        "playbook_name.$": "$$.StateMachine.Name",
+        "playbook_event_details.$": "$$.Execution.Input"
+      },
+      "Next": "New_Interaction_State"
+    },
+    "PLAYBOOK_FORMATTER": {
+      "Type": "Pass",
+      "Parameters": {
+        "execution_id.$": "$.execution_id",
+        "artifacts.$": "$.artifacts",
+        "results": {},
+        "errors": {}
+      },
+      "Next": "New_Interaction_State"
+    },
+    "New_Interaction_State": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke.waitForTaskToken",
+      "Parameters": {
+        "FunctionName": "${{self:custom.slack.PromptForConfirmation}}",
+        "Payload": {
+          "sfn_context": {
+            "execution_id.$": "$.execution_id",
+            "artifacts.$": "$.artifacts",
+            "errors.$": "$.errors",
+            "results.$": "$.results",
+            "State_Config": {
+              "Name": "New_Interaction_State",
+              "Parameters": {
+                "no_text": "No",
+                "prompt_text": "Are you happy?",
+                "receiver": "Slack_User_For_Response",
+                "target": "$.results.Validate_Username.name",
+                "target_type": "user",
+                "text": "Hi, are you happy?",
+                "yes_text": "Yes"
+              }
+            }
+          },
+          "task_token.$": "$$.Task.Token"
+        }
+      },
+      "Next": "Slack_User_For_Response",
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ]
+    },
+    "Slack_User_For_Response": {
+      "Type": "Task",
+      "Parameters": {
+        "execution_id.$": "$.execution_id",
+        "artifacts.$": "$.artifacts",
+        "errors.$": "$.errors",
+        "results.$": "$.results",
+        "State_Config": {
+          "Name": "Slack_User_For_Response",
+          "Parameters": {
+            "no_text": "No",
+            "prompt_text": "Are you happy?",
+            "receiver": "Await_User_Response",
+            "target": "$.results.Validate_Username.name",
+            "target_type": "user",
+            "text": "Hi, are you happy?",
+            "yes_text": "Yes"
+          }
+        }
+      },
+      "Catch": [{ "ErrorEquals": ["States.ALL"], "Next": "Is_User_Happy" }],
+      "Retry": [
+        {
+          "ErrorEquals": ["ConnectionError"],
+          "IntervalSeconds": 30,
+          "MaxAttempts": 2,
+          "BackoffRate": 2
+        },
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "Resource": "${{self:custom.slack.PromptForConfirmation}}",
+      "Next": "Await_User_Response"
+    },
+    "Await_User_Response": {
+      "Type": "Task",
+      "Resource": "${{self:custom.core.AwaitMessageResponseActivity}}",
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        },
+        {
+          "ErrorEquals": ["Lambda.ServiceException"],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "Is_User_Happy"
+    },
+    "Is_User_Happy": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.results.result",
+          "StringEquals": "false",
+          "Next": "User_Is_Not_Happy"
+        }
+      ],
+      "Default": "User_Is_Happy"
+    },
+    "User_Is_Happy": { "Type": "Pass", "Next": "Celebrate_With_User" },
+    "Celebrate_With_User": {
+      "Type": "Task",
+      "Parameters": {
+        "execution_id.$": "$.execution_id",
+        "artifacts.$": "$.artifacts",
+        "errors.$": "$.errors",
+        "results.$": "$.results",
+        "State_Config": {
+          "Name": "Celebrate_With_User",
+          "Parameters": {
+            "message_template": "I'm happy too! Yay!",
+            "target": "user",
+            "target_type": "channel"
+          }
+        }
+      },
+      "Resource": "${{self:custom.slack.SendMessage}}",
+      "Next": "Mark_As_Success",
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ]
+    },
+    "Mark_As_Success": { "Type": "Succeed" },
+    "User_Is_Not_Happy": { "Type": "Pass", "Next": "Parallel_Cheer_User_Up" },
+    "Parallel_Cheer_User_Up": {
+      "Type": "Parallel",
+      "Next": "merge_parallel_cheer_user_up",
+      "Branches": [
+        {
+          "StartAt": "Slack_User_Happiness",
+          "States": {
+            "Slack_User_Happiness": {
+              "Type": "Task",
+              "Parameters": {
+                "execution_id.$": "$.execution_id",
+                "artifacts.$": "$.artifacts",
+                "errors.$": "$.errors",
+                "results.$": "$.results",
+                "State_Config": {
+                  "Name": "Slack_User_Happiness",
+                  "Parameters": {
+                    "message_template": "I'm happy too! Yay!",
+                    "target": "user",
+                    "target_type": "channel"
+                  }
+                }
+              },
+              "Resource": "${{self:custom.slack.PromptForConfirmation}}",
+              "End": true,
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.ServiceException",
+                    "Lambda.AWSLambdaException",
+                    "Lambda.SdkClientException"
+                  ],
+                  "IntervalSeconds": 2,
+                  "MaxAttempts": 6,
+                  "BackoffRate": 2
+                }
+              ]
+            }
+          }
+        },
+        {
+          "StartAt": "Order_Pizza_For_User",
+          "States": {
+            "Order_Pizza_For_User": {
+              "Type": "Task",
+              "Parameters": {
+                "execution_id.$": "$.execution_id",
+                "artifacts.$": "$.artifacts",
+                "errors.$": "$.errors",
+                "results.$": "$.results",
+                "State_Config": {
+                  "Name": "Order_Pizza_For_User",
+                  "Parameters": {
+                    "type": "bbq with bacon bits",
+                    "restaurant": "Five10 Pizza"
+                  }
+                }
+              },
+              "Resource": "${{self:custom.hubgrub.PlaceOrder}}",
+              "Next": "Pour_Coffee_For_User",
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.ServiceException",
+                    "Lambda.AWSLambdaException",
+                    "Lambda.SdkClientException"
+                  ],
+                  "IntervalSeconds": 2,
+                  "MaxAttempts": 6,
+                  "BackoffRate": 2
+                }
+              ]
+            },
+            "Pour_Coffee_For_User": {
+              "Type": "Task",
+              "Parameters": {
+                "execution_id.$": "$.execution_id",
+                "artifacts.$": "$.artifacts",
+                "errors.$": "$.errors",
+                "results.$": "$.results",
+                "State_Config": {
+                  "Name": "Pour_Coffee_For_User",
+                  "Parameters": { "how": "coffee, sugar, cream" }
+                }
+              },
+              "Resource": "${{self:custom.iotBrewer.PourCoffee}}",
+              "End": true,
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.ServiceException",
+                    "Lambda.AWSLambdaException",
+                    "Lambda.SdkClientException"
+                  ],
+                  "IntervalSeconds": 2,
+                  "MaxAttempts": 6,
+                  "BackoffRate": 2
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "merge_parallel_cheer_user_up": {
+      "Type": "Task",
+      "Resource": "${{self:custom.core.MergeParallelOutput}}",
+      "Catch": [],
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "End_Cheer_Up"
+    },
+    "End_Cheer_Up": {
+      "Type": "Task",
+      "Parameters": {
+        "execution_id.$": "$.execution_id",
+        "artifacts.$": "$.artifacts",
+        "errors.$": "$.errors",
+        "results.$": "$.results",
+        "State_Config": {
+          "Name": "End_Cheer_Up",
+          "Parameters": { "status": "done" }
+        }
+      },
+      "Resource": "${{self.custom.jira.TransitionIssue}}",
+      "End": true
+    }
+  }
+}

--- a/test/mocks/playbooks/pb_parallel_and_interaction/playbook.json
+++ b/test/mocks/playbooks/pb_parallel_and_interaction/playbook.json
@@ -1,150 +1,153 @@
 {
-    "Playbook": "Check_User_Happiness",
-    "Comment": "Sample Playbook to Geolocate an IP",
-    "StartAt": "New_Interaction_State",
-    "States": {
-        "New_Interaction_State": {
-            "Type": "Interaction",
-            "Resource": "${{self:custom.slack.PromptForConfirmation}}",
-            "Parameters": {
-                "no_text": "No",
-                "prompt_text": "Are you happy?",
-                "receiver": "Slack_User_For_Response",
-                "target": "$.results.Validate_Username.name",
-                "target_type": "user",
-                "text": "Hi, are you happy?",
-                "yes_text": "Yes"
-            },
-            "Next": "Slack_User_For_Response"
-        },
-        "Slack_User_For_Response": {
-            "Type": "Task",
-            "Parameters": {
-                "no_text": "No",
-                "prompt_text": "Are you happy?",
-                "receiver": "Await_User_Response",
-                "target": "$.results.Validate_Username.name",
-                "target_type": "user",
-                "text": "Hi, are you happy?",
-                "yes_text": "Yes"
-            },
-            "Catch": [
-                {
-                    "ErrorEquals": ["States.ALL"],
-                    "Next": "Is_User_Happy"
-                }
-            ],
-            "Retry": [
-                {
-                    "ErrorEquals": ["ConnectionError"],
-                    "IntervalSeconds": 30,
-                    "MaxAttempts": 2,
-                    "BackoffRate": 2
-                }
-            ],
-            "Resource": "${{self:custom.slack.PromptForConfirmation}}",
-            "Next": "Await_User_Response"
-        },
-        "Await_User_Response": {
-            "Type": "Task",
-            "Resource": "${{self:custom.core.AwaitMessageResponseActivity}}",
-            "Retry": [
-                {
-                    "ErrorEquals": ["Lambda.AWSLambdaException", "Lambda.SdkClientException"],
-                    "IntervalSeconds": 2,
-                    "MaxAttempts": 6,
-                    "BackoffRate": 2
-                }
-            ],
-            "Next": "Is_User_Happy"
-        },
-        "Is_User_Happy": {
-            "Type": "Choice",
-            "Choices": [
-                {
-                    "Variable": "$.results.result",
-                    "StringEquals": "false",
-                    "Next": "User_Is_Not_Happy"
-                }
-            ],
-            "Default": "User_Is_Happy"
-        },
-        "User_Is_Happy": {
-            "Type": "Pass",
-            "Next": "Celebrate_With_User"
-        },
-        "Celebrate_With_User": {
-            "Type": "Task",
-            "Parameters": {
+  "Playbook": "CheckUserHappiness",
+  "Comment": "Sample Playbook to Geolocate an IP",
+  "StartAt": "New_Interaction_State",
+  "States": {
+    "New_Interaction_State": {
+      "Type": "Interaction",
+      "Resource": "${{self:custom.slack.PromptForConfirmation}}",
+      "Parameters": {
+        "no_text": "No",
+        "prompt_text": "Are you happy?",
+        "receiver": "Slack_User_For_Response",
+        "target": "$.results.Validate_Username.name",
+        "target_type": "user",
+        "text": "Hi, are you happy?",
+        "yes_text": "Yes"
+      },
+      "Next": "Slack_User_For_Response"
+    },
+    "Slack_User_For_Response": {
+      "Type": "Task",
+      "Parameters": {
+        "no_text": "No",
+        "prompt_text": "Are you happy?",
+        "receiver": "Await_User_Response",
+        "target": "$.results.Validate_Username.name",
+        "target_type": "user",
+        "text": "Hi, are you happy?",
+        "yes_text": "Yes"
+      },
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Is_User_Happy"
+        }
+      ],
+      "Retry": [
+        {
+          "ErrorEquals": ["ConnectionError"],
+          "IntervalSeconds": 30,
+          "MaxAttempts": 2,
+          "BackoffRate": 2
+        }
+      ],
+      "Resource": "${{self:custom.slack.PromptForConfirmation}}",
+      "Next": "Await_User_Response"
+    },
+    "Await_User_Response": {
+      "Type": "Task",
+      "Resource": "${{self:custom.core.AwaitMessageResponseActivity}}",
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "Is_User_Happy"
+    },
+    "Is_User_Happy": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.results.result",
+          "StringEquals": "false",
+          "Next": "User_Is_Not_Happy"
+        }
+      ],
+      "Default": "User_Is_Happy"
+    },
+    "User_Is_Happy": {
+      "Type": "Pass",
+      "Next": "Celebrate_With_User"
+    },
+    "Celebrate_With_User": {
+      "Type": "Task",
+      "Parameters": {
+        "message_template": "I'm happy too! Yay!",
+        "target": "user",
+        "target_type": "channel"
+      },
+      "Resource": "${{self:custom.slack.SendMessage}}",
+      "Next": "Mark_As_Success"
+    },
+    "Mark_As_Success": {
+      "Type": "Succeed"
+    },
+    "User_Is_Not_Happy": {
+      "Type": "Pass",
+      "Next": "Parallel_Cheer_User_Up"
+    },
+    "Parallel_Cheer_User_Up": {
+      "Type": "Parallel",
+      "Next": "End_Cheer_Up",
+      "Branches": [
+        {
+          "StartAt": "Slack_User_Happiness",
+          "States": {
+            "Slack_User_Happiness": {
+              "Type": "Task",
+              "Parameters": {
                 "message_template": "I'm happy too! Yay!",
                 "target": "user",
                 "target_type": "channel"
-            },
-            "Resource": "${{self:custom.slack.SendMessage}}",
-            "Next": "Mark_As_Success"
-        },
-        "Mark_As_Success": {
-            "Type": "Succeed"
-        },
-        "User_Is_Not_Happy": {
-            "Type": "Pass",
-            "Next": "Parallel_Cheer_User_Up"
-        },
-        "Parallel_Cheer_User_Up": {
-            "Type": "Parallel",
-            "Next": "End_Cheer_Up",
-            "Branches": [{
-                "StartAt": "Slack_User_Happiness",
-                "States": {
-                    "Slack_User_Happiness": {
-                        "Type": "Task",
-                        "Parameters": {
-                            "message_template": "I'm happy too! Yay!",
-                            "target": "user",
-                            "target_type": "channel"
-                        },
-                        "Resource": "${{self:custom.slack.PromptForConfirmation}}",
-                        "End": true
-                    }
-                }
-            },
-            {
-                "StartAt": "Order_Pizza_For_User",
-                "States": {
-                    "Order_Pizza_For_User": {
-                        "Type": "Task",
-                        "Parameters": {
-                            "type": "bbq with bacon bits",
-                            "restaurant": "Five10 Pizza"
-                        },
-                        "Resource": "${{self:custom.hubgrub.PlaceOrder}}",
-                        "Next": "Pour_Coffee_For_User"
-                    },
-                    "Pour_Coffee_For_User": {
-                        "Type": "Task",
-                        "Parameters": {
-                            "how": "coffee, sugar, cream"
-                        },
-                        "Resource": "${{self:custom.iotBrewer.PourCoffee}}",
-                        "End": true
-                    }
-                }
+              },
+              "Resource": "${{self:custom.slack.PromptForConfirmation}}",
+              "End": true
             }
-            ]
+          }
         },
-        "End_Cheer_Up": {
-            "Type": "Task",
-            "Parameters": {
-                "status": "done"
+        {
+          "StartAt": "Order_Pizza_For_User",
+          "States": {
+            "Order_Pizza_For_User": {
+              "Type": "Task",
+              "Parameters": {
+                "type": "bbq with bacon bits",
+                "restaurant": "Five10 Pizza"
+              },
+              "Resource": "${{self:custom.hubgrub.PlaceOrder}}",
+              "Next": "Pour_Coffee_For_User"
             },
-            "Resource": "${{self.custom.jira.TransitionIssue}}",
-            "End": true
+            "Pour_Coffee_For_User": {
+              "Type": "Task",
+              "Parameters": {
+                "how": "coffee, sugar, cream"
+              },
+              "Resource": "${{self:custom.iotBrewer.PourCoffee}}",
+              "End": true
+            }
+          }
         }
+      ]
     },
-    "Decorators": {
-        "DisableDefaultRetry": {
-            "tasks": ["End_Cheer_Up"],
-            "all": false
-        }
+    "End_Cheer_Up": {
+      "Type": "Task",
+      "Parameters": {
+        "status": "done"
+      },
+      "Resource": "${{self.custom.jira.TransitionIssue}}",
+      "End": true
     }
+  },
+  "Decorators": {
+    "DisableDefaultRetry": {
+      "tasks": ["End_Cheer_Up"]
+    }
+  }
 }

--- a/test/mocks/playbooks/pb_parse_nonstring/playbook.json
+++ b/test/mocks/playbooks/pb_parse_nonstring/playbook.json
@@ -1,30 +1,30 @@
 {
-        "Playbook": "testing_non_string_renderer",
-        "Comment": "mock nonstring renderer playbook",
-        "StartAt": "Celebrate_With_User",
-        "States": {
-            "Celebrate_With_User": {
-                "Type": "Task",
-                "Parameters": {
-                    "message_template": "I'm happy too! Yay!",
-                    "target": "U123456",
-                    "target_type": "slack_id"
-                },
-                "Resource": "${{self:custom.slack.SendMessage}}",
-                "Next": "Wait_24_Hour"
-            },
-            "Wait_24_Hour" : {
-                "Type" : "Wait",
-                "Seconds" : "apb_render_nonstring_value(${{self:custom.Wait_24_Hour_Config.${{self:provider.stage}}}})",
-                "Next": "End_Cheer_Up"
-            },
-            "End_Cheer_Up": {
-                "Type": "Task",
-                "Parameters": {
-                    "status": "done"
-                },
-                "Resource": "${{self.custom.jira.TransitionIssue}}",
-                "End": true
-            }
-        }
+  "Playbook": "testingNonStringRenderer",
+  "Comment": "mock nonstring renderer playbook",
+  "StartAt": "Celebrate_With_User",
+  "States": {
+    "Celebrate_With_User": {
+      "Type": "Task",
+      "Parameters": {
+        "message_template": "I'm happy too! Yay!",
+        "target": "U123456",
+        "target_type": "slack_id"
+      },
+      "Resource": "${{self:custom.slack.SendMessage}}",
+      "Next": "Wait_24_Hour"
+    },
+    "Wait_24_Hour": {
+      "Type": "Wait",
+      "Seconds": "apb_render_nonstring_value(${{self:custom.Wait_24_Hour_Config.${{self:provider.stage}}}})",
+      "Next": "End_Cheer_Up"
+    },
+    "End_Cheer_Up": {
+      "Type": "Task",
+      "Parameters": {
+        "status": "done"
+      },
+      "Resource": "${{self.custom.jira.TransitionIssue}}",
+      "End": true
     }
+  }
+}

--- a/test/mocks/playbooks/pb_task_failure_handler/playbook.json
+++ b/test/mocks/playbooks/pb_task_failure_handler/playbook.json
@@ -1,78 +1,79 @@
 {
-    "Playbook": "Test_TFH",
-    "Comment": "mock tfh playbook",
-    "StartAt": "Celebrate_With_User",
-    "States": {
-        "Celebrate_With_User": {
-            "Type": "Task",
-            "Parameters": {
+  "Playbook": "TestTFH",
+  "Comment": "mock tfh playbook",
+  "StartAt": "Celebrate_With_User",
+  "States": {
+    "Celebrate_With_User": {
+      "Type": "Task",
+      "Parameters": {
+        "message_template": "I'm happy too! Yay!",
+        "target": "U123456",
+        "target_type": "slack_id"
+      },
+      "Resource": "${{self:custom.slack.SendMessage}}",
+      "Next": "Parallel_Cheer_User_Up"
+    },
+    "Parallel_Cheer_User_Up": {
+      "Type": "Parallel",
+      "Next": "End_Cheer_Up",
+      "Branches": [
+        {
+          "StartAt": "Slack_User_Happiness",
+          "States": {
+            "Slack_User_Happiness": {
+              "Type": "Task",
+              "Parameters": {
                 "message_template": "I'm happy too! Yay!",
                 "target": "U123456",
                 "target_type": "slack_id"
-            },
-            "Resource": "${{self:custom.slack.SendMessage}}",
-            "Next": "Parallel_Cheer_User_Up"
-        },
-        "Parallel_Cheer_User_Up": {
-            "Type": "Parallel",
-            "Next": "End_Cheer_Up",
-            "Branches": [{
-                "StartAt": "Slack_User_Happiness",
-                "States": {
-                    "Slack_User_Happiness": {
-                        "Type": "Task",
-                        "Parameters": {
-                            "message_template": "I'm happy too! Yay!",
-                            "target": "U123456",
-                            "target_type": "slack_id"
-                        },
-                        "Resource": "${{self:custom.slack.PromptForConfirmation}}",
-                        "End": true
-                    }
-                }
-            },
-            {
-                "StartAt": "Order_Pizza_For_User",
-                "States": {
-                    "Order_Pizza_For_User": {
-                        "Type": "Task",
-                        "Parameters": {
-                            "type": "bbq with bacon bits",
-                            "restaurant": "Five10 Pizza"
-                        },
-                        "Resource": "${{self:custom.hubgrub.PlaceOrder}}",
-                        "Next": "Pour_Coffee_For_User"
-                    },
-                    "Pour_Coffee_For_User": {
-                        "Type": "Task",
-                        "Parameters": {
-                            "how": "coffee, sugar, cream"
-                        },
-                        "Resource": "${{self:custom.iotBrewer.PourCoffee}}",
-                        "End": true
-                    }
-                }
+              },
+              "Resource": "${{self:custom.slack.PromptForConfirmation}}",
+              "End": true
             }
-            ]
+          }
         },
-        "End_Cheer_Up": {
-            "Type": "Task",
-            "Parameters": {
-                "status": "done"
+        {
+          "StartAt": "Order_Pizza_For_User",
+          "States": {
+            "Order_Pizza_For_User": {
+              "Type": "Task",
+              "Parameters": {
+                "type": "bbq with bacon bits",
+                "restaurant": "Five10 Pizza"
+              },
+              "Resource": "${{self:custom.hubgrub.PlaceOrder}}",
+              "Next": "Pour_Coffee_For_User"
             },
-            "Resource": "${{self.custom.jira.TransitionIssue}}",
-            "End": true
+            "Pour_Coffee_For_User": {
+              "Type": "Task",
+              "Parameters": {
+                "how": "coffee, sugar, cream"
+              },
+              "Resource": "${{self:custom.iotBrewer.PourCoffee}}",
+              "End": true
+            }
+          }
         }
+      ]
     },
-    "Decorators": {
-        "TaskFailureHandler": {
-            "Type": "Task",
-            "Parameters": {
-                "message_template": "Sorry, unable to complete this workflow! :(",
-                "target": "socless_errors",
-                "target_type": "channel"
-            },
-            "Resource": "${{self:custom.slack.SendMessage}}"
-        }
+    "End_Cheer_Up": {
+      "Type": "Task",
+      "Parameters": {
+        "status": "done"
+      },
+      "Resource": "${{self.custom.jira.TransitionIssue}}",
+      "End": true
     }
+  },
+  "Decorators": {
+    "TaskFailureHandler": {
+      "Type": "Task",
+      "Parameters": {
+        "message_template": "Sorry, unable to complete this workflow! :(",
+        "target": "socless_errors",
+        "target_type": "channel"
+      },
+      "Resource": "${{self:custom.slack.SendMessage}}"
+    }
+  }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -240,7 +240,7 @@ describe("apb", () => {
         logging: true,
       }).StateMachineYaml;
       assert(
-        with_logging.Resources.Check_User_Happiness.Properties
+        with_logging.Resources.CheckUserHappiness.Properties
           .LoggingConfiguration
       );
     });
@@ -248,8 +248,7 @@ describe("apb", () => {
     it("should exclude logging based on config object {logging: false}", () => {
       const no_logging = apb_with_parallel_and_interactions.StateMachineYaml;
       assert(
-        !no_logging.Resources.Check_User_Happiness.Properties
-          .LoggingConfiguration
+        !no_logging.Resources.CheckUserHappiness.Properties.LoggingConfiguration
       );
     });
   });

--- a/test/test_validators.js
+++ b/test/test_validators.js
@@ -1,0 +1,44 @@
+const assert = require("assert");
+const { validatePlaybook } = require("../dist/validators");
+const {
+  pb_parallel_and_interaction,
+  pb_task_failure_handler,
+  pb_parse_nonstring,
+  socless_slack_integration_test_playbook,
+  pb_with_missing_top_level_keys,
+  hello_world,
+} = require("./mocks");
+
+describe("validatePlaybook", () => {
+  it("Validation Succeeds with Valid Playbooks", () => {
+    const validPlaybooks = [
+      hello_world,
+      pb_parallel_and_interaction,
+      socless_slack_integration_test_playbook,
+      pb_parse_nonstring,
+      pb_task_failure_handler,
+    ];
+
+    validPlaybooks
+      .map((playbook) => validatePlaybook(playbook))
+      .map(({ isValid, errors }, index) => {
+        assert(
+          isValid,
+          `Playbook with index ${index} in list of tested playbooks has the following errors ${JSON.stringify(
+            errors,
+            null,
+            2
+          )}`
+        );
+        assert(errors.length === 0);
+      });
+  });
+
+  it("Validation Fails and returns errors given invalid playbooks", () => {
+    const { isValid, errors } = validatePlaybook(
+      pb_with_missing_top_level_keys
+    );
+    assert(!isValid);
+    assert(errors.length > 0);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,23 +1,25 @@
 {
-  "include" : [
-    "./lib"
-  ],
+  "include": ["./lib"],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 
     /* Basic Options */
     // "incremental": true,                         /* Enable incremental compilation */
-    "target": "es5",                                /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
-    "module": "commonjs",                           /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    "lib": ["es2017", "dom"],                       /* Specify library files to be included in the compilation. */
-    "allowJs": true,                             /* Allow javascript files to be compiled. */
+    "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+    "lib": [
+      "es2017",
+      "dom"
+    ] /* Specify library files to be included in the compilation. */,
+    "resolveJsonModule": true /* Allow Json files to be imported as modules */,
+    "allowJs": true /* Allow javascript files to be compiled. */,
     // "checkJs": true,                             /* Report errors in .js files. */
     // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
     // "declaration": true,                         /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                           /* Generates corresponding '.map' file. */
     // "outFile": "./",                             /* Concatenate and emit output to single file. */
-    "outDir": "./dist",                              /* Redirect output structure to the directory. */
+    "outDir": "./dist" /* Redirect output structure to the directory. */,
     // "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                           /* Enable project compilation */
     // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
@@ -28,8 +30,8 @@
     // "isolatedModules": true,                     /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     /* Strict Type-Checking Options */
-    "strict": true,                                 /* Enable all strict type-checking options. */
-    "noImplicitAny": false,                       /* Raise error on expressions and declarations with an implied 'any' type. */
+    "strict": true /* Enable all strict type-checking options. */,
+    "noImplicitAny": false /* Raise error on expressions and declarations with an implied 'any' type. */,
     // "strictNullChecks": true,                    /* Enable strict null checks. */
     // "strictFunctionTypes": true,                 /* Enable strict checking of function types. */
     // "strictBindCallApply": true,                 /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
@@ -53,7 +55,7 @@
     // "typeRoots": [],                             /* List of folders to include type definitions from. */
     // "types": [],                                 /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true,                        /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,                /* Allow accessing UMD globals from modules. */
 
@@ -68,7 +70,7 @@
     // "emitDecoratorMetadata": true,               /* Enables experimental support for emitting type metadata for decorators. */
 
     /* Advanced Options */
-    "skipLibCheck": true,                           /* Skip type checking of declaration files. */
-    "forceConsistentCasingInFileNames": true        /* Disallow inconsistently-cased references to the same file. */
+    "skipLibCheck": true /* Skip type checking of declaration files. */,
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   }
 }


### PR DESCRIPTION
This PR is a first pass at adding schema and rules validation for SOCless Playbook definition objects. The work done here is heavily influenced by [asl-validator library](https://github.com/ChristopheBougere/asl-validator/tree/master/src/schemas). As a matter of fact, some of the schemas used for validation here are directly lifted from that repository and slightly tweaked to match the socless use-case.


Here's an overall overview of changes made
- JSON Schemas & AJV library are used to validate Playbook Definition. Validation is done using the validatePlaybook function which is called now called as the first step in instantiating an apb object
- Older validation functions that are no longer needed because of AJV & JSON Schemas validation have been removed
- vestigial functions like resolveStateName have been removed
- typescript declaration files are now being generated to support typescript libraries that are using apb
- Fixed names of some of the test playbooks that don't actually abide by the socless playbooks schema


Major Files / Folders added:
- lib/schemas - This is a folder that contains JSON Schemas that describe the valid shape of the different state types in SOCless (e.g task, decorators, pass, etc)
- validators.ts - this file contains the validation code (ajv config as well as generated validators)


*Things to Note*

This PR is one of many PRs intended to "make APB better". It is being released now to keep the number of code changes in need of review small.

The overall plan is
* Add validation of Schema (this PR)
* Add validation of State Machine rules (next PR)
* Optimize implementation of Validation (next+1 PR)
* Refactor APB internals from Class to Functions [stretch] (next+2 PR)
* Refactor APB tests (next+3 PR)




**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
