### PR TITLE
Fix bug in validator that incorrectly raised error when not is nested in AND or OR Choice Rule

### DIFF
--- a/dist/apb.d.ts
+++ b/dist/apb.d.ts
@@ -1,4 +1,4 @@
-import { PlaybookDefinition, SoclessTaskStepParameters, StepFunction, State, TaskState, CompleteStateMachineCloudFormation, ApbConfig } from "./types";
+import { PlaybookDefinition, SoclessTaskStepParameters, StepFunction, State, CompleteStateMachineCloudFormation, ApbConfig } from "./types";
 export declare class apb {
     apb_config: ApbConfig;
     DecoratorFlags: any;
@@ -37,7 +37,7 @@ export declare class apb {
     transformTaskState(stateName: string, stateConfig: any, States: any, DecoratorFlags: any): {};
     transformInteractionState(stateName: any, stateConfig: any, States: any, DecoratorFlags: any): {};
     transformParallelState(stateName: any, stateConfig: any, States: any, DecoratorFlags: any): {
-        [x: string]: TaskState;
+        [x: string]: {};
         [x: number]: {};
     };
     transformStates(States?: Record<string, State>, DecoratorFlags?: any): {};

--- a/dist/apb.js
+++ b/dist/apb.js
@@ -21,14 +21,10 @@ var __rest = (this && this.__rest) || function (s, e) {
         }
     return t;
 };
-var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
-        if (ar || !(i in from)) {
-            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
-            ar[i] = from[i];
-        }
-    }
-    return to.concat(ar || Array.prototype.slice.call(from));
+var __spreadArray = (this && this.__spreadArray) || function (to, from) {
+    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
+        to[j] = from[i];
+    return to;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.apb = void 0;
@@ -39,7 +35,7 @@ var apb = /** @class */ (function () {
     function apb(definition, apb_config) {
         var _a, _b;
         if (apb_config === void 0) { apb_config = {}; }
-        var _c = (0, validators_1.validatePlaybook)(definition), isValid = _c.isValid, errors = _c.errors;
+        var _c = validators_1.validatePlaybook(definition), isValid = _c.isValid, errors = _c.errors;
         if (!isValid) {
             throw new errors_1.PlaybookValidationError("Playbook Definition is invalid " + JSON.stringify(errors, null, 2));
         }
@@ -215,7 +211,7 @@ var apb = /** @class */ (function () {
             stateName !== this.DecoratorFlags.TaskFailureHandlerName) {
             var currentCatchConfig = newConfig.Catch || [];
             var handlerCatchConfig = [this.genTaskFailureHandlerCatchConfig(stateName)];
-            newConfig.Catch = __spreadArray(__spreadArray([], currentCatchConfig, true), handlerCatchConfig, true);
+            newConfig.Catch = __spreadArray(__spreadArray([], currentCatchConfig), handlerCatchConfig);
         }
         var handle_state_parameters = newConfig.Parameters;
         if (handle_state_parameters) {
@@ -250,7 +246,7 @@ var apb = /** @class */ (function () {
             stateName !== this.DecoratorFlags.TaskFailureHandlerName) {
             var currentCatchConfig = newConfig.Catch || [];
             var handlerCatchConfig = [this.genTaskFailureHandlerCatchConfig(stateName)];
-            newConfig.Catch = __spreadArray(__spreadArray([], currentCatchConfig, true), handlerCatchConfig, true);
+            newConfig.Catch = __spreadArray(__spreadArray([], currentCatchConfig), handlerCatchConfig);
         }
         newConfig.Parameters = this.generateParametersForSoclessInteraction(stateName, newConfig.Parameters, newConfig.Resource);
         newConfig.Resource = "arn:aws:states:::lambda:invoke.waitForTaskToken";
@@ -274,7 +270,7 @@ var apb = /** @class */ (function () {
             // add catch for top level
             var currentCatchConfig = topLevel.Catch || [];
             var handlerCatchConfig = [this.genTaskFailureHandlerCatchConfig(stateName)];
-            topLevel.Catch = __spreadArray(__spreadArray([], currentCatchConfig, true), handlerCatchConfig, true);
+            topLevel.Catch = __spreadArray(__spreadArray([], currentCatchConfig), handlerCatchConfig);
             // add catch and retries for merge output task
             mergeParallelOutputState.Catch = [
                 this.genTaskFailureHandlerCatchConfig(mergeParallelOutputStateName),

--- a/dist/schemas/index.d.ts
+++ b/dist/schemas/index.d.ts
@@ -26,6 +26,10 @@ export declare const DecoratorTaskSchema: Joi.ObjectSchema<any>;
  * a ChoiceBooleanExpression.
  */
 export declare const NestedDataTestExpression: Joi.ObjectSchema<any>;
+/**
+ * Represents a Not rule that is Nested in a ChoiceBooleanExpression
+ */
+export declare const NestedNotExpression: Joi.ObjectSchema<any>;
 export declare const ChoiceBooleanExpression: Joi.ObjectSchema<any>;
 export declare const TopLevelDataTestExpression: Joi.ObjectSchema<any>;
 export declare const ChoiceSchema: Joi.ObjectSchema<any>;

--- a/dist/schemas/index.js
+++ b/dist/schemas/index.js
@@ -9,7 +9,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.ValidateStateHelper = exports.PlaybookSchema = exports.DecoratorsSchema = exports.TaskFailureHandlerSchema = exports.DisableDefaultRetry = exports.StateMachineSchema = exports.MapSchema = exports.ParallelSchema = exports.ChoiceSchema = exports.TopLevelDataTestExpression = exports.ChoiceBooleanExpression = exports.NestedDataTestExpression = exports.DecoratorTaskSchema = exports.TaskSchema = exports.Catch = exports.Catcher = exports.Retry = exports.Retrier = exports.ErrorEquals = exports.WaitSchema = exports.FailSchema = exports.SucceedSchema = exports.PassSchema = exports.ISOTimestamp = exports.PathExpression = exports.StateName = exports.APBRenderNontStringValue = exports.StateNameRegex = void 0;
+exports.ValidateStateHelper = exports.PlaybookSchema = exports.DecoratorsSchema = exports.TaskFailureHandlerSchema = exports.DisableDefaultRetry = exports.StateMachineSchema = exports.MapSchema = exports.ParallelSchema = exports.ChoiceSchema = exports.TopLevelDataTestExpression = exports.ChoiceBooleanExpression = exports.NestedNotExpression = exports.NestedDataTestExpression = exports.DecoratorTaskSchema = exports.TaskSchema = exports.Catch = exports.Catcher = exports.Retry = exports.Retrier = exports.ErrorEquals = exports.WaitSchema = exports.FailSchema = exports.SucceedSchema = exports.PassSchema = exports.ISOTimestamp = exports.PathExpression = exports.StateName = exports.APBRenderNontStringValue = exports.StateNameRegex = void 0;
 var joi_1 = __importDefault(require("joi"));
 exports.StateNameRegex = /^[a-zA-Z0-9_]{1,}/;
 exports.APBRenderNontStringValue = joi_1.default.string().pattern(
@@ -145,12 +145,18 @@ exports.NestedDataTestExpression = joi_1.default.object({
     IsString: joi_1.default.boolean().valid(true),
     IsTimestamp: joi_1.default.boolean().valid(true),
 }).xor("StringEquals", "StringEqualsPath", "StringLessThan", "StringLessThanPath", "StringGreaterThan", "StringGreaterThanPath", "StringLessThanEquals", "StringLessThanEqualsPath", "StringGreaterThanEquals", "StringGreaterThanEqualsPath", "StringMatches", "NumericEquals", "NumericEqualsPath", "NumericLessThan", "NumericLessThanPath", "NumericGreaterThan", "NumericGreaterThanPath", "NumericLessThanEquals", "NumericLessThanEqualsPath", "NumericGreaterThanEquals", "NumericGreaterThanEqualsPath", "BooleanEquals", "BooleanEqualsPath", "TimestampEquals", "TimestampEqualsPath", "TimestampLessThan", "TimestampLessThanPath", "TimestampGreaterThan", "TimestampGreaterThanPath", "TimestampLessThanEquals", "TimestampLessThanEqualsPath", "TimestampGreaterThanEquals", "TimestampGreaterThanEqualsPath", "IsBoolean", "IsNull", "IsPresent", "IsNumeric", "IsString", "IsTimestamp");
+/**
+ * Represents a Not rule that is Nested in a ChoiceBooleanExpression
+ */
+exports.NestedNotExpression = joi_1.default.object({
+    Not: exports.NestedDataTestExpression,
+});
 // done
 exports.ChoiceBooleanExpression = joi_1.default.object({
     Next: exports.StateName.required(),
     Not: exports.NestedDataTestExpression,
-    And: joi_1.default.array().items(exports.NestedDataTestExpression.required()),
-    Or: joi_1.default.array().items(exports.NestedDataTestExpression.required()),
+    And: joi_1.default.array().items(exports.NestedDataTestExpression, exports.NestedNotExpression).min(1),
+    Or: joi_1.default.array().items(exports.NestedDataTestExpression, exports.NestedNotExpression).min(1),
 }).xor("And", "Not", "Or");
 // done
 exports.TopLevelDataTestExpression = exports.NestedDataTestExpression.append({

--- a/lib/schemas/index.ts
+++ b/lib/schemas/index.ts
@@ -201,12 +201,20 @@ export const NestedDataTestExpression = Joi.object({
   "IsTimestamp"
 );
 
+/**
+ * Represents a Not rule that is Nested in a ChoiceBooleanExpression
+ */
+
+export const NestedNotExpression = Joi.object({
+  Not: NestedDataTestExpression,
+});
+
 // done
 export const ChoiceBooleanExpression = Joi.object({
   Next: StateName.required(),
   Not: NestedDataTestExpression,
-  And: Joi.array().items(NestedDataTestExpression.required()),
-  Or: Joi.array().items(NestedDataTestExpression.required()),
+  And: Joi.array().items(NestedDataTestExpression, NestedNotExpression).min(1),
+  Or: Joi.array().items(NestedDataTestExpression, NestedNotExpression).min(1),
 }).xor("And", "Not", "Or");
 
 // done

--- a/test/mocks/playbooks/hello_world/playbook.json
+++ b/test/mocks/playbooks/hello_world/playbook.json
@@ -1,11 +1,38 @@
 {
   "Playbook": "HelloWorld",
-  "Comment": "A simple playbook used predominantly for testing the playbook.events.schedule feature of sls-apb in serverless.yaml",
+  "Comment": "A simple playbook used for testing",
   "StartAt": "HelloWorld",
   "States": {
     "HelloWorld": {
       "Type": "Pass",
-      "End": true
+      "Next": "Choice_State"
+    },
+    "How_Are_You": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.results.result",
+          "StringEquals": "true",
+          "Next": "Fine"
+        },
+        {
+          "And": [
+            {
+              "Not": {
+                "Variable": "$.stateinput.key",
+                "IsPresent": true
+              }
+            }
+          ],
+          "Next": "Not_Fine"
+        }
+      ]
+    },
+    "Fine": {
+      "Type": "Succeed"
+    },
+    "Not_Fine": {
+      "Type": "Fail"
     }
   }
 }


### PR DESCRIPTION
This fixes the ChoiceRule validator schema to account for the fact that Not expressions can be nested in AND/OR expressions of Choice Rules.


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
