### PR TITLE
Update type signature for Choice State

### DIFF
--- a/dist/types/step_function.d.ts
+++ b/dist/types/step_function.d.ts
@@ -24,8 +24,10 @@ export interface ChoiceState extends BaseStateTerminal {
     InputPath?: string;
     OutputPath?: string;
 }
-/** Shared attributes for all regular States (Wait, Pass) & (Task, Parallel, Map, Interaction)
-/* https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-common-fields.html */
+/**
+ * Shared attributes for all regular States (Wait, Pass) & (Task, Parallel, Map, Interaction)
+ * https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-common-fields.html
+ */
 export interface CommonStateFields {
     Type: string;
     Comment?: string;
@@ -83,7 +85,7 @@ export interface Catch {
     Next: string;
     ResultPath?: String;
 }
-/**https://docs.aws.amazon.com/step-functions/latest/dg/concepts-error-handling.html#error-handling-retrying-after-an-error */
+/** https://docs.aws.amazon.com/step-functions/latest/dg/concepts-error-handling.html#error-handling-retrying-after-an-error */
 export interface Retry {
     ErrorEquals: string[];
     IntervalSeconds: number;
@@ -91,12 +93,14 @@ export interface Retry {
     BackoffRate: number;
 }
 /** https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-choice-state.html#amazon-states-language-choice-state-rules  */
-export interface ChoiceRule {
-    Variable: string;
-    Next?: string;
-    And?: ChoiceRule[];
-    Not?: ChoiceRule[];
-    Or?: ChoiceRule[];
+export interface ChoiceRule extends ChoiceRuleNested {
+    Next: string;
+}
+export interface ChoiceRuleNested {
+    Variable?: string;
+    And?: ChoiceRuleNested[];
+    Not?: ChoiceRuleNested[];
+    Or?: ChoiceRuleNested[];
     StringEquals?: string;
     StringEqualsPath?: string;
     StringLessThan?: string;

--- a/dist/types/step_function.d.ts
+++ b/dist/types/step_function.d.ts
@@ -99,8 +99,8 @@ export interface ChoiceRule extends ChoiceRuleNested {
 export interface ChoiceRuleNested {
     Variable?: string;
     And?: ChoiceRuleNested[];
-    Not?: ChoiceRuleNested[];
     Or?: ChoiceRuleNested[];
+    Not?: ChoiceRuleNested;
     StringEquals?: string;
     StringEqualsPath?: string;
     StringLessThan?: string;

--- a/lib/types/step_function.ts
+++ b/lib/types/step_function.ts
@@ -111,12 +111,15 @@ export interface Retry {
 }
 
 /** https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-choice-state.html#amazon-states-language-choice-state-rules  */
-export interface ChoiceRule {
-  Variable: string;
-  Next?: string;
-  And?: ChoiceRule[];
-  Not?: ChoiceRule[];
-  Or?: ChoiceRule[];
+export interface ChoiceRule extends ChoiceRuleNested {
+  Next: string;
+}
+
+export interface ChoiceRuleNested {
+  Variable?: string;
+  And?: ChoiceRuleNested[];
+  Not?: ChoiceRuleNested[];
+  Or?: ChoiceRuleNested[];
   StringEquals?: string;
   StringEqualsPath?: string;
   StringLessThan?: string;

--- a/lib/types/step_function.ts
+++ b/lib/types/step_function.ts
@@ -118,8 +118,8 @@ export interface ChoiceRule extends ChoiceRuleNested {
 export interface ChoiceRuleNested {
   Variable?: string;
   And?: ChoiceRuleNested[];
-  Not?: ChoiceRuleNested[];
   Or?: ChoiceRuleNested[];
+  Not?: ChoiceRuleNested;
   StringEquals?: string;
   StringEqualsPath?: string;
   StringLessThan?: string;


### PR DESCRIPTION
Amazon Step Functions Choice states contain an array of `ChoiceRule`s. ChoiceRules can contain more nested ChoiceRules if they have the `And`, `Or`, or `Not` keys, however these nested rules cannot contain a `Next` and MUST contain a `Variable` field. If a top-level choice rule contains any of the modifier keys, it is not required to have a `Variable` key.

To reflect this, I have split the type signatures for choice rule into those at the top level and those that are not:
- Top-level choice rules have an optional Variable field and a required Next field. 
- Nested choice rules cannot have a Next field and have a required Variable field.
- "Not" keys are now single objects, instead of arrays


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
